### PR TITLE
docs: document native node installer preview

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import TransactionPathVisualizer from '@/components/transaction-path-visualizer';
 import HeroTitle from '@/components/hero-title';
 import NetworkStats from '@/components/network-stats';
+import NativeNodeInstaller from '@/components/native-node-installer';
 import HowItWorks from '@/components/how-it-works';
 import LiveSimulation from '@/components/live-simulation';
 import NetworkComparison from '@/components/network-comparison';
@@ -41,6 +42,7 @@ export default function HomePage() {
       <main className="flex flex-col p-4 md:p-10">
         <HeroTitle />
         <NetworkStats />
+        <NativeNodeInstaller />
         <HowItWorks />
         {/* <QuickStartSection /> */}
         {/* <LiveSimulation /> */}

--- a/components/native-node-installer.tsx
+++ b/components/native-node-installer.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+import Section from './section';
+
+const UNIX_COMMAND = `curl -sSfL https://raw.githubusercontent.com/nervosnetwork/fiber/develop/tools/install/install.sh \\
+  | INSTALL_REF=develop FNN_VERSION=0.9.0-rc7 bash`;
+
+const WINDOWS_COMMAND = `$env:INSTALL_REF="develop"
+$env:FNN_VERSION="0.9.0-rc7"
+$env:NETWORK="testnet"
+$env:INSTALL_DIR="$HOME\\.fiber"
+irm https://raw.githubusercontent.com/nervosnetwork/fiber/develop/tools/install/install.ps1 | iex`;
+
+type OperatingSystem = 'unix' | 'windows';
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+const INSTALLERS: Record<
+  OperatingSystem,
+  {
+    label: string;
+    prompt: string;
+    command: string;
+  }
+> = {
+  unix: {
+    label: 'macOS / Linux',
+    prompt: '$',
+    command: UNIX_COMMAND,
+  },
+  windows: {
+    label: 'Windows PowerShell',
+    prompt: 'PS>',
+    command: WINDOWS_COMMAND,
+  },
+};
+
+export default function NativeNodeInstaller() {
+  const [operatingSystem, setOperatingSystem] =
+    useState<OperatingSystem>('unix');
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+  const installer = INSTALLERS[operatingSystem];
+
+  const selectOperatingSystem = (nextOperatingSystem: OperatingSystem) => {
+    setOperatingSystem(nextOperatingSystem);
+    setCopyStatus('idle');
+  };
+
+  const copyCommand = async () => {
+    try {
+      await navigator.clipboard.writeText(installer.command);
+      setCopyStatus('copied');
+      window.setTimeout(() => setCopyStatus('idle'), 1600);
+    } catch {
+      setCopyStatus('failed');
+    }
+  };
+
+  const copyAnnouncement =
+    copyStatus === 'copied'
+      ? 'Copied'
+      : copyStatus === 'failed'
+        ? 'Copy failed'
+        : 'Copy command';
+
+  return (
+    <Section
+      description={
+        <Link
+          className="w-full md:w-60 h-[60px] p-2 border border-white flex shrink-0 justify-center items-center gap-sm cursor-pointer hover-invert"
+          href="/docs/quick-start/run-a-node/rust#automated-installer-preview"
+        >
+          <span className="w-6 h-6 relative flex items-center justify-center">
+            <Image src="/external.svg" alt="" width={20} height={20} />
+          </span>
+          <span className="text-center text-primary text-button">
+            FULL GUIDE
+          </span>
+        </Link>
+      }
+      headerLayout="split"
+      title={
+        <>
+          Run <span className="text-tertiary">a Native</span> Fiber Node
+        </>
+      }
+      titleDescription={
+        <p className="text-secondary text-body2">
+          Join Fiber&apos;s peer-to-peer network, connect directly with peers,
+          and participate on Testnet by running your own native node.
+        </p>
+      }
+    >
+      <div className="self-stretch flex flex-col justify-start items-start">
+        <div className="self-stretch overflow-hidden border border-invisible bg-layer-01">
+          <div className="flex flex-wrap items-center justify-between gap-sm border-b border-invisible bg-layer-02 px-sm py-sm">
+            <div
+              aria-label="Choose an operating system"
+              className="inline-flex items-stretch border border-invisible bg-layer-01 p-1"
+              role="tablist"
+            >
+              {(Object.keys(INSTALLERS) as OperatingSystem[]).map((key) => (
+                <button
+                  aria-controls={`installer-panel-${key}`}
+                  aria-selected={operatingSystem === key}
+                  className={`px-sm py-2 border inline-flex justify-center items-center transition-colors ${
+                    operatingSystem === key
+                      ? 'bg-primary border-primary text-inverse'
+                      : 'border-transparent text-tertiary hover:text-primary'
+                  }`}
+                  id={`installer-tab-${key}`}
+                  key={key}
+                  onClick={() => selectOperatingSystem(key)}
+                  role="tab"
+                  type="button"
+                >
+                  <span className="text-center text-body3">
+                    {INSTALLERS[key].label}
+                  </span>
+                </button>
+              ))}
+            </div>
+
+            <div className="hidden sm:flex items-center gap-lg text-tertiary text-body3">
+              <span>
+                Network: <span className="text-primary">Testnet</span>
+              </span>
+              <span className="hidden md:inline">
+                Target Version:{' '}
+                <span className="text-primary">0.9.0-rc7</span>
+              </span>
+            </div>
+          </div>
+
+          <div className="grid w-full bg-layer-01 p-sm md:p-md">
+            {(Object.keys(INSTALLERS) as OperatingSystem[]).map((key) => (
+              <div
+                aria-hidden={operatingSystem !== key}
+                aria-labelledby={`installer-tab-${key}`}
+                className={`col-start-1 row-start-1 w-full min-w-0 h-full flex flex-col ${
+                  operatingSystem === key
+                    ? 'visible'
+                    : 'invisible pointer-events-none'
+                }`}
+                id={`installer-panel-${key}`}
+                key={key}
+                role="tabpanel"
+              >
+                <div className="relative flex-1 border border-invisible bg-layer-02">
+                  <button
+                    aria-label="Copy command"
+                    className="absolute top-2 right-2 size-10 border border-invisible inline-flex items-center justify-center hover-invert z-10"
+                    onClick={copyCommand}
+                    type="button"
+                  >
+                    <Image src="/icon-copy.svg" alt="" width={18} height={18} />
+                    <span aria-live="polite" className="sr-only">
+                      {copyAnnouncement}
+                    </span>
+                  </button>
+
+                  <pre className="m-0 min-h-32 py-sm pl-sm pr-16 md:py-md md:pl-md md:pr-12 overflow-x-auto whitespace-pre-wrap break-words text-secondary text-body3 font-mono">
+                    <code>
+                      <span className="text-primary">
+                        {INSTALLERS[key].prompt}{' '}
+                      </span>
+                      {INSTALLERS[key].command}
+                    </code>
+                  </pre>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -2,22 +2,36 @@ import Divider from './divider';
 
 interface SectionProps {
   title?: React.ReactNode;
+  titleDescription?: React.ReactNode;
+  description?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
   showDivider?: boolean;
   layout?: 'vertical' | 'horizontal' | 'responsive'; // Add responsive option
+  headerLayout?: 'stacked' | 'split';
 }
 
-export default function Section({ title, children, className = '', showDivider = true, layout = 'vertical' }: SectionProps) {
+export default function Section({
+  title,
+  titleDescription,
+  description,
+  children,
+  className = '',
+  showDivider = true,
+  layout = 'vertical',
+  headerLayout = 'stacked',
+}: SectionProps) {
   // Responsive layout: vertical on mobile, horizontal on md+
   if (layout === 'responsive') {
     return (
       <>
         <section className={`self-stretch flex flex-col lg:flex-row justify-start items-start gap-lg mb-xxl ${className}`}>
-          {title && (
-            <h1 className="w-full lg:flex-[3] text-primary mb-xl lg:mb-0">
-              {title}
-            </h1>
+          {(title || titleDescription || description) && (
+            <div className="w-full lg:flex-[3] mb-xl lg:mb-0">
+              {title && <h1 className="text-primary">{title}</h1>}
+              {titleDescription && <div className="mt-md">{titleDescription}</div>}
+              {description && <div className="mt-md">{description}</div>}
+            </div>
           )}
           <div className="w-full lg:flex-[7]">
             {children}
@@ -32,10 +46,12 @@ export default function Section({ title, children, className = '', showDivider =
     return (
       <>
         <section className={`self-stretch flex justify-start items-start gap-lg mb-xxl ${className}`}>
-          {title && (
-            <h1 className="flex-[3] text-primary">
-              {title}
-            </h1>
+          {(title || titleDescription || description) && (
+            <div className="flex-[3]">
+              {title && <h1 className="text-primary">{title}</h1>}
+              {titleDescription && <div className="mt-md">{titleDescription}</div>}
+              {description && <div className="mt-md">{description}</div>}
+            </div>
           )}
           <div className="flex-[7]">
             {children}
@@ -49,10 +65,34 @@ export default function Section({ title, children, className = '', showDivider =
   return (
     <>
       <section className={`self-stretch inline-flex flex-col justify-start items-start mb-xxl ${className}`}>
-        {title && (
-          <h1 className="self-stretch justify-center text-primary mb-xl">
-            {title}
-          </h1>
+        {(title || titleDescription || description) && (
+          <div
+            className={`self-stretch ${
+              headerLayout === 'split'
+                ? 'flex flex-col md:flex-row justify-between items-start gap-lg'
+                : ''
+            } mb-xl`}
+          >
+            {headerLayout === 'split' ? (
+              <>
+                {(title || titleDescription) && (
+                  <div className="min-w-0 flex-1">
+                    {title && <h1 className="justify-center text-primary">{title}</h1>}
+                    {titleDescription && <div className="mt-md">{titleDescription}</div>}
+                  </div>
+                )}
+                {description && (
+                  <div className="w-full md:w-auto md:ml-auto">{description}</div>
+                )}
+              </>
+            ) : (
+              <>
+                {title && <h1 className="justify-center text-primary">{title}</h1>}
+                {titleDescription && <div className="mt-md">{titleDescription}</div>}
+                {description && <div className="mt-md">{description}</div>}
+              </>
+            )}
+          </div>
         )}
         {children}
       </section>

--- a/content/docs/operate/backup.mdx
+++ b/content/docs/operate/backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Fiber Node Backup
 description: "How to backup and restore Fiber node data"
-date: 2026-06-09
+date: 2026-08-02
 author: "gpBlockchain"
 authorUrl: "https://github.com/gpBlockchain"
 dependencies:
@@ -15,6 +15,10 @@ dependencies:
 Stop the node, tar the entire node directory, store the archive and `FIBER_SECRET_KEY_PASSWORD` securely. To restore, extract the archive and start the node with the same password.
 
 This guide explains how to securely back up Fiber node data to safeguard funds, maintain node identity, and ensure smooth migration or upgrades. **Never store plaintext private keys**, as they risk theft if exposed.
+
+<Callout type="info" title="Nodes created by the installer">
+Back up the entire install directory. The Unix bootstrap installer uses `~/.fiber` by default; guided Unix and Windows installs use the directory you selected. After restoring it, run `./start-node.sh` on Linux/macOS or `.\start-node.ps1` on Windows and provide the same `FIBER_SECRET_KEY_PASSWORD`.
+</Callout>
 
 ## 1. Why Back Up?
 

--- a/content/docs/quick-start/run-a-node/index.mdx
+++ b/content/docs/quick-start/run-a-node/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overview"
 description: "What it means to run a Fiber node, the available node forms, and how to pick the right deployment for your use case"
-date: 2026-06-18
+date: 2026-08-02
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -42,7 +42,7 @@ The native Rust binary is the full production node. It runs as a standalone proc
 | **Network exposure** | Public IP recommended for routing; private nodes can connect through public relay nodes |
 | **Interaction** | `fnn-cli` or raw JSON-RPC |
 
-Use the native node when you need full control, persistent storage, and the ability to accept inbound channel requests from the public internet.
+Use the native node when you need full control, persistent storage, and the ability to accept inbound channel requests from the public internet. A guided installer is being prepared to download the release bundle, configure the selected network, set up keys, and generate a reusable startup script.
 
 → [Run a Native Node](/docs/quick-start/run-a-node/rust)
 
@@ -84,13 +84,15 @@ Use the WASM node when you want users to bring their own node inside a web app, 
 
 The fastest way to experiment. You run `fnn` locally against Fiber Testnet, fund the address from a testnet faucet, and open channels with the public Testnet relay nodes. No public IP is required because you initiate outbound connections to the public nodes.
 
-Typical flow:
+Typical flow with the upcoming installer:
 
-1. Download or build the `fnn` binary.
-2. Generate or export a CKB private key.
-3. Copy `config/testnet/config.yml` and set `FIBER_SECRET_KEY_PASSWORD`.
-4. Start the node and connect to a public Testnet node.
+1. Bootstrap the FNN bundle, `ckb-cli`, and Testnet configuration.
+2. Run the guided setup to create or import a CKB account.
+3. Save `FIBER_SECRET_KEY_PASSWORD` and back up the install directory.
+4. Start the node with the generated `start-node` script.
 5. Open a channel and try [Basic Transfer](/docs/quick-start/basic-transfer).
+
+Until a Fiber release includes the installer, follow the release-only manual path in [Run a Native Node](/docs/quick-start/run-a-node/rust#manual-installation).
 
 ### Production Public Node
 
@@ -134,9 +136,9 @@ Testnet is the recommended place to start. Once you are comfortable with channel
 
 ## Before You Start
 
-At a minimum, you need a **CKB private key**. You can generate one with [`ckb-cli`](https://github.com/nervosnetwork/ckb-cli) or export it from a CKB wallet.
+At a minimum, you need a **CKB private key**. The native installer can download `ckb-cli` and guide you through creating or importing an account; manual and Docker setups can use an existing key exported from a CKB wallet.
 
-The detailed prerequisites — CKB RPC endpoints, `config.yml`, how much CKB to reserve, and whether a one-way channel lets the other side join without depositing CKB — are covered in the native ([build from source](/docs/quick-start/run-a-node/rust) or [Docker](/docs/quick-start/run-a-node/docker)) and [WASM](/docs/quick-start/run-a-node/fiberjs) guides.
+The detailed prerequisites — CKB RPC endpoints, `config.yml`, how much CKB to reserve, and whether a one-way channel lets the other side join without depositing CKB — are covered in the native ([installer or manual setup](/docs/quick-start/run-a-node/rust) or [Docker](/docs/quick-start/run-a-node/docker)) and [WASM](/docs/quick-start/run-a-node/fiberjs) guides.
 
 <Callout type="warning">
 Keep your node data directory, especially `fiber/store` and the `ckb/key` file, backed up and secure. Losing channel state can mean losing funds.

--- a/content/docs/quick-start/run-a-node/rust.mdx
+++ b/content/docs/quick-start/run-a-node/rust.mdx
@@ -1,109 +1,195 @@
 ---
 title: "Run a Native Node"
-description: "Run a native Fiber Network Node (FNN) binary on your local machine or server"
-date: 2026-06-09
+description: "Install and run a native Fiber Network Node (FNN) on your local machine or server"
+date: 2026-08-02
 dependencies:
   - name: Fiber Node
-    minVersion: "0.9.0-rc5"
-    link: "https://github.com/nervosnetwork/fiber/releases/tag/v0.9.0-rc5"
+    minVersion: "0.9.0-rc7"
+    link: "https://github.com/nervosnetwork/fiber/releases/tag/v0.9.0-rc7"
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
 ## TL;DR
 
-Download the FNN binary, set up a private key, configure `config.yml`, and start the node. In 5 minutes you'll have a Fiber node running on Testnet.
+The Fiber installer downloads the FNN release bundle and `ckb-cli`, prepares the selected network configuration, guides you through key setup, and creates a reusable startup script.
 
-## Prerequisites
+<Callout type="warn" title="Installer release status">
+The installer was merged into Fiber's `develop` branch in [PR #1262](https://github.com/nervosnetwork/fiber/pull/1262), after `v0.9.0-rc7` was published. It is not part of a Fiber release yet. The preview below is for Testnet evaluation only; use [manual installation](#manual-installation) for a release-only setup, and do not use the preview with Mainnet funds.
+</Callout>
 
-- [Git](https://git-scm.com/) (if building from source)
-- [Rust](https://www.rust-lang.org/) and [Cargo](https://doc.rust-lang.org/cargo/) (if building from source)
-- Basic understanding of command line operations
-- [ckb-cli](https://github.com/nervosnetwork/ckb-cli) tool for key management
+## Choose an Installation Method
 
-## Building and Setting Up Your Node
+| Method | Best for | Status |
+|--------|----------|--------|
+| [Automated installer preview](#automated-installer-preview) | Evaluating the simplified setup on Testnet | Merged, not released |
+| [Manual installation](#manual-installation) | Current releases and custom builds | Available now |
+| [Docker](/docs/quick-start/run-a-node/docker) | Reproducible deployments without local binaries | Available now |
+
+## Automated Installer Preview
+
+The installer supports Linux, macOS, and 64-bit Windows. On Linux and macOS it recognizes `x86_64` and ARM64 release bundles; Windows currently uses the `x86_64` bundle.
+
+### Linux and macOS
+
+Run the bootstrap step. The explicit `develop` ref is required while the installer remains unreleased:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/nervosnetwork/fiber/develop/tools/install/install.sh \
+  | INSTALL_REF=develop FNN_VERSION=0.9.0-rc7 bash
+```
+
+This non-interactive step installs the release bundle and `ckb-cli` into `~/.fiber`, writes the Testnet configuration, and saves the guided installer. It does not create or import your CKB key.
+
+Run the guided step to set up the key and startup script:
+
+```bash
+~/.fiber/tools/install/install.sh ~/.fiber testnet
+```
+
+The guided installer can create a new CKB account or import an existing account. Save the wallet password and the `FIBER_SECRET_KEY_PASSWORD` securely; they protect different operations and may be different values.
+
+When setup finishes, accept the prompt to start FNN or start it later with:
+
+```bash
+cd ~/.fiber
+./start-node.sh
+```
+
+### Windows PowerShell
+
+The Windows installer performs the guided setup in one pass. Use Windows PowerShell 5.1 or newer:
+
+```powershell
+$env:INSTALL_REF = "develop"
+$env:FNN_VERSION = "0.9.0-rc7"
+$env:NETWORK = "testnet"
+$env:INSTALL_DIR = "$HOME\.fiber"
+irm https://raw.githubusercontent.com/nervosnetwork/fiber/develop/tools/install/install.ps1 | iex
+```
+
+After stopping the node, restart it with:
+
+```powershell
+cd $HOME\.fiber
+.\start-node.ps1
+```
+
+You can also run `start-node.bat` from Command Prompt or double-click it in the install directory.
+
+### What the Installer Creates
+
+The install directory contains the complete node state and tools:
+
+| Path | Purpose |
+|------|---------|
+| `fnn` / `fnn.exe` | Fiber node binary |
+| `fnn-cli` / `fnn-cli.exe` | CLI for the local RPC endpoint |
+| `config.yml` | Active network configuration |
+| `ckb/key` | CKB private key, encrypted after the first successful start |
+| `fiber/` | Node identity and channel database |
+| `start-node.sh` / `start-node.ps1` | Reusable startup command |
+
+<Callout type="warning" title="Keep the password with your backup">
+Every restart requires the same `FIBER_SECRET_KEY_PASSWORD` that encrypted `ckb/key`. If either the encrypted key or its password is lost, the key cannot be recovered from that file. Back up the entire install directory and store the password separately in a password manager.
+</Callout>
+
+### Mainnet Requirements
+
+Start on Testnet. A Mainnet installation additionally requires a trusted CKB RPC endpoint. The installer validates that the endpoint is reachable and belongs to the selected network; non-interactive Mainnet setup requires `CKB_RPC_URL` explicitly.
+
+Use a separate install directory for each network. The installer records the selected network and refuses to reuse a directory containing another network's data.
+
+<Callout type="warn">
+Wait for a Fiber release that includes PR #1262 before using the installer on Mainnet. After that release, pin production automation to the released installer and FNN version instead of the moving `develop` branch.
+</Callout>
+
+## Manual Installation
+
+Use this path with current Fiber releases or when you need to build FNN yourself.
+
+### Prerequisites
+
+- Basic command-line experience
+- [`ckb-cli`](https://github.com/nervosnetwork/ckb-cli) for key management
+- [Git](https://git-scm.com/), [Rust](https://www.rust-lang.org/), and [Cargo](https://doc.rust-lang.org/cargo/) only when building from source
 
 ### 1. Obtain the FNN Binary
 
-You can either download a pre-built binary from the [Fiber GitHub Releases](https://github.com/nervosnetwork/fiber/releases) page or build it from source:
+Download a pre-built bundle from [Fiber Releases](https://github.com/nervosnetwork/fiber/releases), or build from source:
 
-```sh
+```bash
 git clone https://github.com/nervosnetwork/fiber.git
 cd fiber
+git checkout v0.9.0-rc7
 cargo build --release
 ```
 
-This document used the [v0.9.0-rc5 binary](https://github.com/nervosnetwork/fiber/releases/tag/v0.9.0-rc5) throughout the guide.
+The examples below use `v0.9.0-rc7`. Keep the binary and configuration from the same release. Omit the checkout step only when you intentionally want to test unreleased source.
 
 <Callout type="info" title="macOS Security">
-If you're using macOS, the downloaded binary may be blocked by Gatekeeper. To resolve this, remove the quarantine attribute:
-```sh
+If Gatekeeper blocks a downloaded binary, remove its quarantine attribute:
+
+```bash
 xattr -d com.apple.quarantine fnn fnn-cli
 ```
 </Callout>
 
-### 2. Create Node Directory
+### 2. Create the Node Directory
 
-Create a dedicated directory for your node and copy the necessary files:
+Create a dedicated directory and copy the binaries and Testnet configuration into it:
 
-```sh
-mkdir /folder-to/my-fnn
-# If using released binary, replace target/release/fnn with the path to your downloaded binary
+```bash
+mkdir -p /folder-to/my-fnn
 cp target/release/fnn /folder-to/my-fnn
-# Copy additional tools (v0.8.0+)
 cp target/release/fnn-cli /folder-to/my-fnn
 cp config/testnet/config.yml /folder-to/my-fnn
 cd /folder-to/my-fnn
 ```
 
-### 3. Set Up Node Keys
+When using a release bundle, copy its `fnn`, `fnn-cli`, and matching `config/testnet/config.yml` instead of the `target/release` files.
 
-FNN includes built-in wallet functionality for signing funding transactions. You'll need to create or import a private key:
+### 3. Create or Import the Node Key
 
-create a new ckb account and get the `lock_arg` of the new account
+FNN's built-in wallet signs channel funding transactions. Create an account and save its `lock_arg`:
 
-```sh
+```bash
 ckb-cli account new
-
-# example output
-# address
-#   mainnet: ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqtp83cu4pk8nysm9dngxezw546dyr5w8esx7rlyt
-#   testnet: ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqtp83cu4pk8nysm9dngxezw546dyr5w8esgvgswn
-# lock_arg: 0x613c71ca86c79921b2b6683644ea574d20e8e3e6
-# lock_hash: 0x1c506178212949e961f5949c916f70f5ba0f3b89b14ce2608f02201a41eb3ef7
 ```
 
-Then export the existing key
+Export the selected account into the node directory:
 
-```sh
-mkdir ckb
-# Export an existing key using ckb-cli
-ckb-cli account export --lock-arg <lock_arg> --extended-privkey-path ./ckb/exported-key
-# Extract just the private key (FNN only needs this part)
+```bash
+mkdir -p ckb
+ckb-cli account export \
+  --lock-arg <lock_arg> \
+  --extended-privkey-path ./ckb/exported-key
 head -n 1 ./ckb/exported-key > ./ckb/key
+rm ./ckb/exported-key
+chmod 600 ./ckb/key
 ```
+
+The key is plaintext until FNN starts successfully for the first time. Keep the directory private during setup.
 
 ### 4. Start the Node
 
-Launch your node with logging enabled:
+Use a strong, unique password. FNN encrypts a plaintext `ckb/key` on first start and requires the same password on every later start:
 
-(You need to set a `FIBER_SECRET_KEY_PASSWORD` environment variable in the startup command to encrypt your wallet private key file. I used 123 here for demo purposes, but I recommend using a strong password.)
-
-```sh
-FIBER_SECRET_KEY_PASSWORD='123' RUST_LOG=info ./fnn -c config.yml -d .
+```bash
+FIBER_SECRET_KEY_PASSWORD='YOUR_STRONG_PASSWORD' \
+  RUST_LOG=info \
+  ./fnn -c config.yml -d .
 ```
 
-> **Expected Output:** You should see log lines indicating the node is starting, connecting to bootnodes, and syncing with the Testnet. The RPC server will be available at `http://127.0.0.1:8227`.
+You should see logs for the RPC service, P2P listener, and bootnode connections. The local RPC endpoint is `http://127.0.0.1:8227` by default.
 
-## Interacting with Your Node
+## Interact with Your Node
 
-Once your node is running, you can interact with it using the RPC interface or the CLI tool.
+Open another terminal in the install directory.
 
-### Using the CLI Tool (v0.8.0+)
+### Use `fnn-cli`
 
-v0.8.0 introduces `fnn-cli`, a command-line interface that provides a convenient way to manage your node without writing raw JSON-RPC requests:
-
-```sh
+```bash
 # View node information
 ./fnn-cli info
 
@@ -117,68 +203,51 @@ v0.8.0 introduces `fnn-cli`, a command-line interface that provides a convenient
 ./fnn-cli --help
 ```
 
-> **Expected Output:** `./fnn-cli info` should return your node's pubkey, alias, and chain info. If you see a connection error, ensure the node is running and `NO_PROXY` is set for local addresses.
+The CLI connects to `http://127.0.0.1:8227` by default.
 
-The CLI connects to the node's RPC endpoint (default: `http://127.0.0.1:8227`).
+<Callout type="info" title="HTTP proxy issues">
+If local CLI calls return `503 Service Unavailable`, exclude loopback addresses from your proxy:
 
-<Callout type="info" title="HTTP Proxy Issues">
-If you encounter a `503 Service Unavailable` error, check if your system has an HTTP proxy configured. The CLI may attempt to route requests through the proxy, which can fail for local addresses.
-
-**Solution:** Set `NO_PROXY` to exclude local addresses:
-```sh
+```bash
 export NO_PROXY=127.0.0.1,localhost
 ./fnn-cli info
 ```
 </Callout>
 
-### Using JSON-RPC Directly
+### Use JSON-RPC
 
-You can also interact with the node using any HTTP client:
-
-```sh
+```bash
 curl -X POST -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"node_info"}' \
   http://127.0.0.1:8227/
 ```
 
-## Version Compatibility and Upgrades
+## Stop and Restart
 
-FNN is under active development, and protocol/storage format changes may occur between versions. Here's how to handle upgrades:
+Press `Ctrl+C` in the FNN terminal to stop the node cleanly.
 
-<Callout type="warn" title="v0.8.0 Breaking Changes">
-v0.8.0 introduces several RPC changes that may affect existing integrations:
+For an installer-created node, use the generated startup script and enter the original `FIBER_SECRET_KEY_PASSWORD` when prompted:
 
-| Change | v0.7.1 | v0.8.0 |
-|--------|--------|--------|
-| Node identifier | `peer_id` (base58) | `pubkey` (hex-encoded secp256k1) |
-| `node_info` response field | `node_id` | `pubkey` |
-| JSON enum format | PascalCase | snake_case (e.g., `CkbHash` → `ckb_hash`) |
-| `ChannelState` format | Regular | SCREAMING_SNAKE_CASE with pipe separator |
-
-Affected RPC methods: `open_channel`, `list_channels`, `disconnect_peer`, `connect_peer`, `node_info`.
-
-New RPC methods in v0.8.0:
-- `open_channel_with_external_funding` - For hardware wallet/external signing
-- `submit_signed_funding_tx` - Submit externally signed transactions
-- `list_payments` - Query payment sessions
-</Callout>
-
-### Safe Upgrade Process
-
-1. Close all active channels before upgrading
-2. Stop the node and clean the storage:
-
-```sh
-rm -rf /folder-to/my-fnn/fiber/store
+```bash
+cd ~/.fiber
+./start-node.sh
 ```
 
-3. Replace the FNN binary and restart
+For a manual installation, rerun the original `fnn` command with the same data directory, configuration, and password.
 
-### Storage Migration
+## Upgrades and Storage Migration
 
-Starting from v0.9.0-rc1, storage migration is handled automatically by FNN on startup. When upgrading, simply start FNN normally and it will detect and apply any necessary migrations to preserve your channel state. No separate migration tool is needed.
+Back up the entire node directory before every upgrade. Starting with `v0.9.0-rc1`, FNN detects supported database versions and performs required migration during startup.
+
+For databases too old for the current binary, use the migration tool from the appropriate older release first. See [Fiber Node Backup](/docs/operate/backup#cross-version-restore) for the version-specific process.
+
+<Callout type="warning">
+Do not delete `fiber/store` as a routine upgrade step. It contains channel state, and losing channel state can put funds at risk.
+</Callout>
 
 ## Next Steps
 
 - [Basic Transfer](/docs/quick-start/basic-transfer) — send your first payment
-- [Config Reference](/docs/guide/node-operator/config-reference) — full configuration options
+- [Connect to Nodes](/docs/operate/connect-nodes) — connect to Fiber peers
+- [Configuration Reference](/docs/operate/config-reference) — review all node settings
+- [Back Up Your Node](/docs/operate/backup) — protect keys, identity, and channel state

--- a/public/icon-copy.svg
+++ b/public/icon-copy.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.25 17.25H6V6.75H17.25V17.25ZM7.5 15.75H15.75V8.25H7.5V15.75ZM12 5.25H10.5V3H2.25V11.25H4.5V12.75H0.75V1.5H12V5.25Z" fill="white"/>
+</svg>

--- a/public/knowledge-base.json
+++ b/public/knowledge-base.json
@@ -822,7 +822,7 @@
     {
       "id": "chunk-117",
       "title": "Module `Cch`",
-      "content": "## Module `Cch`\n\nRPC module for cross chain hub demonstration.\n\n### Method `send_btc`\n\nCreates a CCH order for a BTC Lightning payee.\n\n#### Params\n\n* `btc_pay_req` - `String`, Payment request string for the BTC Lightning payee.\n* `currency` - [Currency](#type-currency), Request currency\n\n#### Returns",
+      "content": "## Module `Cch`\n\nRPC module for cross chain hub demonstration.\n\n> **Testnet cWBTC Faucet**: [faucet-cwbtc.ckb.dev](https://faucet-cwbtc.ckb.dev) provides free cWBTC test tokens for CCH development. See the [Cross-Chain HTLC guide](/docs/res/cross-chain-htlc) for setup and usage.\n\n### Method `send_btc`\n\nCreates a CCH order for a BTC Lightning payee.\n\n#### Params\n\n* `btc_pay_req` - `String`, Payment request string for the BTC Lightning payee.\n* `currency` - [Currency](#type-currency), Request currency\n\n#### Returns",
       "url": "/docs/api-reference/cross-chain/cch",
       "source": "docs/api-reference/cross-chain/cch.mdx"
     },
@@ -4287,14 +4287,14 @@
     {
       "id": "chunk-612",
       "title": "Fiber Node Backup",
-      "content": "## TL;DR\n\nStop the node, tar the entire node directory, store the archive and `FIBER_SECRET_KEY_PASSWORD` securely. To restore, extract the archive and start the node with the same password.\n\nThis guide explains how to securely back up Fiber node data to safeguard funds, maintain node identity, and ensure smooth migration or upgrades. **Never store plaintext private keys**, as they risk theft if exposed.\n\n## 1. Why Back Up?\n\nBackups protect:\n- **Funds**: The encrypted private key (`ckb/key`) and its password (`FIBER_SECRET_KEY_PASSWORD`) are critical for accessing funds. Losing either makes funds unrecoverable.\n- **Node Identity**: The network ID key (`fiber/sk`) allows other nodes to recognize your node. Losing it disrupts network communication.",
+      "content": "## TL;DR\n\nStop the node, tar the entire node directory, store the archive and `FIBER_SECRET_KEY_PASSWORD` securely. To restore, extract the archive and start the node with the same password.\n\nThis guide explains how to securely back up Fiber node data to safeguard funds, maintain node identity, and ensure smooth migration or upgrades. **Never store plaintext private keys**, as they risk theft if exposed.\n\n<Callout type=\"info\" title=\"Nodes created by the installer\">\nBack up the entire install directory. The Unix bootstrap installer uses `~/.fiber` by default; guided Unix and Windows installs use the directory you selected. After restoring it, run `./start-node.sh` on Linux/macOS or `.\\start-node.ps1` on Windows and provide the same `FIBER_SECRET_KEY_PASSWORD`.\n</Callout>",
       "url": "/docs/operate/backup",
       "source": "docs/operate/backup.mdx"
     },
     {
       "id": "chunk-613",
       "title": "Fiber Node Backup",
-      "content": "**Warning**: Always stop the node before backing up to prevent data corruption, which could cause errors or loss of funds.\n\n## 2. Backing Up Node Data\n\nBack up the entire node directory (`node1`), which includes:\n- `ckb/key` (encrypted private key)\n- `fiber/sk` (network ID key)\n- `fiber/store` (database files)\n- `config.yml` (configuration)",
+      "content": "## 1. Why Back Up?\n\nBackups protect:\n- **Funds**: The encrypted private key (`ckb/key`) and its password (`FIBER_SECRET_KEY_PASSWORD`) are critical for accessing funds. Losing either makes funds unrecoverable.\n- **Node Identity**: The network ID key (`fiber/sk`) allows other nodes to recognize your node. Losing it disrupts network communication.\n\n**Warning**: Always stop the node before backing up to prevent data corruption, which could cause errors or loss of funds.\n\n## 2. Backing Up Node Data\n\nBack up the entire node directory (`node1`), which includes:\n- `ckb/key` (encrypted private key)\n- `fiber/sk` (network ID key)\n- `fiber/store` (database files)\n- `config.yml` (configuration)",
       "url": "/docs/operate/backup",
       "source": "docs/operate/backup.mdx"
     },
@@ -4567,4329 +4567,4455 @@
     {
       "id": "chunk-652",
       "title": "Basic Transfer Example",
-      "content": "import { Callout } from 'fumadocs-ui/components/callout';\nimport { Tabs, Tab } from 'fumadocs-ui/components/tabs';\n\n## TL;DR\n\nSet up two local nodes, open a channel between them, and send a CKB payment from one to the other. The whole process takes about 10 minutes.\n\n<Callout type=\"info\" title=\"Want a zero-install introduction?\">\nThis page is the native, two-terminal workflow. To start a WASM node directly in your browser and connect it to a public node over WSS, see [Run a WASM Node](/docs/quick-start/run-a-node/fiberjs).\n</Callout>\n\n## Overview\n\nThis guide walks you through setting up and executing a basic token ([CKB](https://explorer.nervos.org/)) transfer between two nodes on the Fiber Testnet.\n\n## Prerequisites",
+      "content": "import { Callout } from 'fumadocs-ui/components/callout';\nimport { Tabs, Tab } from 'fumadocs-ui/components/tabs';\n\n## TL;DR\n\nSet up two local nodes, open a channel between them, and send a CKB payment from one to the other. The whole process takes about 10 minutes.\n\n## Overview\n\nThis guide walks you through setting up and executing a basic token ([CKB](https://explorer.nervos.org/)) transfer between two nodes on the Fiber Testnet.\n\n## Prerequisites\n\n- [Git](https://git-scm.com/) (if building from source)\n- [Rust](https://www.rust-lang.org/) and [Cargo](https://doc.rust-lang.org/cargo/) (if building from source)\n- Basic understanding of command line operations\n- [curl](https://curl.se/) for making RPC calls\n- [ckb-cli](https://github.com/nervosnetwork/ckb-cli) for generating keys",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-653",
       "title": "Basic Transfer Example",
-      "content": "- [Git](https://git-scm.com/) (if building from source)\n- [Rust](https://www.rust-lang.org/) and [Cargo](https://doc.rust-lang.org/cargo/) (if building from source)\n- Basic understanding of command line operations\n- [curl](https://curl.se/) for making RPC calls\n- [ckb-cli](https://github.com/nervosnetwork/ckb-cli) for generating keys\n\n## Setting Up Your Nodes\n\n### 1. Prepare Fiber Binary\n\nDownload the latest release binary from the [Fiber GitHub Releases](https://github.com/nervosnetwork/fiber/releases) page, or build from source:\n\n```sh\ngit clone https://github.com/nervosnetwork/fiber.git\ncd fiber\ncargo build --release\n```\n\n<Callout type=\"info\" title=\"macOS Security\">\nIf you're using macOS, remove the quarantine attribute:\n```sh\nxattr -d com.apple.quarantine fnn fnn-cli\n```\n</Callout>",
+      "content": "## Setting Up Your Nodes\n\n### 1. Prepare Fiber Binary\n\nDownload the latest release binary from the [Fiber GitHub Releases](https://github.com/nervosnetwork/fiber/releases) page, or build from source:\n\n```sh\ngit clone https://github.com/nervosnetwork/fiber.git\ncd fiber\ncargo build --release\n```\n\n<Callout type=\"info\" title=\"macOS Security\">\nIf you're using macOS, remove the quarantine attribute:\n```sh\nxattr -d com.apple.quarantine fnn fnn-cli\n```\n</Callout>\n\n<Callout type=\"info\" title=\"HTTP Proxy Issues\">\nIf you encounter 503 errors when using fnn-cli, run:\n```sh\nexport NO_PROXY=127.0.0.1,localhost\n```\n</Callout>\n\n### 2. Create Data Directories\n\n```sh\n# For Node 1\nmkdir node1\ncp target/release/fnn node1/\ncp target/release/fnn-cli node1/\ncp config/testnet/config.yml node1/",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-654",
       "title": "Basic Transfer Example",
-      "content": "<Callout type=\"info\" title=\"HTTP Proxy Issues\">\nIf you encounter 503 errors when using fnn-cli, run:\n```sh\nexport NO_PROXY=127.0.0.1,localhost\n```\n</Callout>\n\n### 2. Create Data Directories\n\n```sh\n# For Node 1\nmkdir node1\ncp target/release/fnn node1/\ncp target/release/fnn-cli node1/\ncp config/testnet/config.yml node1/\n\n# For Node 2\nmkdir node2\ncp target/release/fnn node2/\ncp target/release/fnn-cli node2/\ncp config/testnet/config.yml node2/\n```\n\n### 3. Configure Node Keys\n\nEach node needs its own private key. Create two separate CKB accounts:\n\n```sh\nckb-cli account new  # for Node 1\nckb-cli account new  # for Node 2\n```\n\nExport the keys:",
+      "content": "# For Node 2\nmkdir node2\ncp target/release/fnn node2/\ncp target/release/fnn-cli node2/\ncp config/testnet/config.yml node2/\n```\n\n### 3. Configure Node Keys\n\nEach node needs its own private key. Create two separate CKB accounts:\n\n```sh\nckb-cli account new  # for Node 1\nckb-cli account new  # for Node 2\n```\n\nExport the keys:\n\n```sh\n# In node1 directory\nmkdir ckb\nckb-cli account export --lock-arg <node1_lock_arg> --extended-privkey-path ./ckb/exported-key\nhead -n 1 ./ckb/exported-key > ./ckb/key\n\n# In node2 directory\nmkdir ckb\nckb-cli account export --lock-arg <node2_lock_arg> --extended-privkey-path ./ckb/exported-key\nhead -n 1 ./ckb/exported-key > ./ckb/key\n```",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-655",
       "title": "Basic Transfer Example",
-      "content": "```sh\n# In node1 directory\nmkdir ckb\nckb-cli account export --lock-arg <node1_lock_arg> --extended-privkey-path ./ckb/exported-key\nhead -n 1 ./ckb/exported-key > ./ckb/key\n\n# In node2 directory\nmkdir ckb\nckb-cli account export --lock-arg <node2_lock_arg> --extended-privkey-path ./ckb/exported-key\nhead -n 1 ./ckb/exported-key > ./ckb/key\n```\n\n<Callout type=\"warning\" title=\"Key File Format\">\nThe `ckb/key` file must contain only the 64-character hex private key (first line), without `0x` prefix.\n</Callout>\n\nGet Testnet funds from [https://faucet.nervos.org](https://faucet.nervos.org/) for both nodes.\n\n### 4. Configure Ports\n\nEdit `config.yml` for each node:\n- Node 1: RPC Port `8227`, P2P Port `8228`\n- Node 2: RPC Port `8237`, P2P Port `8238`",
+      "content": "<Callout type=\"warning\" title=\"Key File Format\">\nThe `ckb/key` file must contain only the 64-character hex private key (first line), without `0x` prefix.\n</Callout>\n\nGet Testnet funds from [https://faucet.nervos.org](https://faucet.nervos.org/) for both nodes.\n\n### 4. Configure Ports\n\nEdit `config.yml` for each node:\n- Node 1: RPC Port `8227`, P2P Port `8228`\n- Node 2: RPC Port `8237`, P2P Port `8238`\n\n<details>\n<summary>View complete config.yml example</summary>",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-656",
       "title": "Basic Transfer Example",
-      "content": "<details>\n<summary>View complete config.yml example</summary>",
+      "content": "```yaml\nfiber:\n  listening_addr: \"/ip4/0.0.0.0/tcp/8228\"\n  bootnode_addrs:\n    - \"/ip4/54.179.226.154/tcp/8228/p2p/Qmes1EBD4yNo9Ywkfe6eRw9tG1nVNGLDmMud1xJMsoYFKy\"\n    - \"/ip4/16.163.7.105/tcp/8228/p2p/QmdyQWjPtbK4NWWsvy8s69NGJaQULwgeQDT5ZpNDrTNaeV\"\n  announce_listening_addr: true\n  chain: testnet\n  scripts:\n    - name: FundingLock\n      script:\n        code_hash: 0x6c67887fe201ee0c7853f1682c0b77c0e6214044c156c7558269390a8afa6d7c\n        hash_type: type\n        args: 0x\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0x3cb7c0304fe53f75bb5727e2484d0beae4bd99d979813c6fc97c3cca569f10f6\n        - cell_dep:\n            out_point:\n              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7\n              index: 0x0\n            dep_type: code\n    - name: CommitmentLock\n      script:\n        code_hash: 0x740dee83f87c6f309824d8fd3fbdd3c8380ee6fc9acc90b1a748438afcdf81d8\n        hash_type: type\n        args: 0x\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0xf7e458887495cf70dd30d1543cad47dc1dfe9d874177bf19291e4db478d5751b\n        - cell_dep:\n            out_point:\n              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7\n              index: 0x0\n            dep_type: code\nrpc:\n  listening_addr: \"127.0.0.1:8227\"\nckb:\n  rpc_url: \"https://testnet.ckbapp.dev/\"\n  udt_whitelist:\n    - name: RUSD\n      script:\n        code_hash: 0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\n        hash_type: type\n        args: 0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0x97d30b723c0b2c66e9cb8d4d0df4ab5d7222cbb00d4a9a2055ce2e5d7f0d8b0f\n      auto_accept_amount: 1000000000\nservices:\n  - fiber\n  - rpc\n  - ckb\n```\n</details>",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-657",
       "title": "Basic Transfer Example",
-      "content": "```yaml\nfiber:\n  listening_addr: \"/ip4/0.0.0.0/tcp/8228\"\n  bootnode_addrs:\n    - \"/ip4/54.179.226.154/tcp/8228/p2p/Qmes1EBD4yNo9Ywkfe6eRw9tG1nVNGLDmMud1xJMsoYFKy\"\n    - \"/ip4/16.163.7.105/tcp/8228/p2p/QmdyQWjPtbK4NWWsvy8s69NGJaQULwgeQDT5ZpNDrTNaeV\"\n  announce_listening_addr: true\n  chain: testnet\n  scripts:\n    - name: FundingLock\n      script:\n        code_hash: 0x6c67887fe201ee0c7853f1682c0b77c0e6214044c156c7558269390a8afa6d7c\n        hash_type: type\n        args: 0x\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0x3cb7c0304fe53f75bb5727e2484d0beae4bd99d979813c6fc97c3cca569f10f6\n        - cell_dep:\n            out_point:\n              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7\n              index: 0x0\n            dep_type: code\n    - name: CommitmentLock\n      script:\n        code_hash: 0x740dee83f87c6f309824d8fd3fbdd3c8380ee6fc9acc90b1a748438afcdf81d8\n        hash_type: type\n        args: 0x\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0xf7e458887495cf70dd30d1543cad47dc1dfe9d874177bf19291e4db478d5751b\n        - cell_dep:\n            out_point:\n              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7\n              index: 0x0\n            dep_type: code\nrpc:\n  listening_addr: \"127.0.0.1:8227\"\nckb:\n  rpc_url: \"https://testnet.ckbapp.dev/\"\n  udt_whitelist:\n    - name: RUSD\n      script:\n        code_hash: 0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\n        hash_type: type\n        args: 0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0x97d30b723c0b2c66e9cb8d4d0df4ab5d7222cbb00d4a9a2055ce2e5d7f0d8b0f\n      auto_accept_amount: 1000000000\nservices:\n  - fiber\n  - rpc\n  - ckb\n```\n</details>",
+      "content": "## Step-by-Step Transfer Process\n\n### 1. Start Both Nodes\n\n```sh\n# Terminal 1 — Node 1\ncd node1\nFIBER_SECRET_KEY_PASSWORD='password1' RUST_LOG=info ./fnn -c config.yml -d .\n\n# Terminal 2 — Node 2\ncd node2\nFIBER_SECRET_KEY_PASSWORD='password2' RUST_LOG=info ./fnn -c config.yml -d .\n```\n\n### 2. Connect the Nodes\n\nFirst get Node 2's pubkey, then connect from Node 1:\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# Get Node 2's pubkey\ncd node2 && ./fnn-cli --url http://127.0.0.1:8237 info | grep pubkey",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-658",
       "title": "Basic Transfer Example",
-      "content": "## Step-by-Step Transfer Process\n\n### 1. Start Both Nodes\n\n```sh\n# Terminal 1 — Node 1\ncd node1\nFIBER_SECRET_KEY_PASSWORD='password1' RUST_LOG=info ./fnn -c config.yml -d .\n\n# Terminal 2 — Node 2\ncd node2\nFIBER_SECRET_KEY_PASSWORD='password2' RUST_LOG=info ./fnn -c config.yml -d .\n```\n\nKeep both terminal processes running while you complete the remaining steps.\n\n### 2. Connect the Nodes\n\nFirst get Node 2's pubkey, then connect from Node 1:\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# Get Node 2's pubkey\ncd node2 && ./fnn-cli --url http://127.0.0.1:8237 info | grep pubkey",
+      "content": "# Connect from Node 1\ncd node1 && ./fnn-cli peer connect_peer --pubkey <node2_pubkey> --address \"/ip4/127.0.0.1/tcp/8238\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\n# Get Node 2's pubkey\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\":\"42\",\"jsonrpc\":\"2.0\",\"method\":\"node_info\"}' \\\n  http://localhost:8237 | grep pubkey",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-659",
       "title": "Basic Transfer Example",
-      "content": "# Connect from Node 1\ncd node1 && ./fnn-cli peer connect_peer --pubkey <node2_pubkey> --address \"/ip4/127.0.0.1/tcp/8238\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\n# Get Node 2's pubkey\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\":\"42\",\"jsonrpc\":\"2.0\",\"method\":\"node_info\"}' \\\n  http://localhost:8237 | grep pubkey",
+      "content": "# Connect from Node 1\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"connect_peer\",\n    \"params\": [{\"pubkey\": \"<node2_pubkey>\", \"address\": \"/ip4/127.0.0.1/tcp/8238\"}]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// Get Node 2's info\nconst node2 = new FiberSDK({ endpoint: \"http://127.0.0.1:8237\" });\nconst info = await node2.getNodeInfo();\nconsole.log(\"Node 2 pubkey:\", info.pubkey);\n\n// Connect from Node 1\nconst sdk = new FiberSDK({ endpoint: \"http://127.0.0.1:8227\" });\nawait sdk.connectPeer({ address: \"/ip4/127.0.0.1/tcp/8238\" });\n```\n  </Tab>\n</Tabs>\n\n### 3. Open a Payment Channel",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-660",
       "title": "Basic Transfer Example",
-      "content": "# Connect from Node 1\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"connect_peer\",\n    \"params\": [{\"pubkey\": \"<node2_pubkey>\", \"address\": \"/ip4/127.0.0.1/tcp/8238\"}]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// Get Node 2's info\nconst node2 = new FiberSDK({ endpoint: \"http://127.0.0.1:8237\" });\nconst info = await node2.getNodeInfo();\nconsole.log(\"Node 2 pubkey:\", info.pubkey);\n\n// Connect from Node 1\nconst sdk = new FiberSDK({ endpoint: \"http://127.0.0.1:8227\" });\nawait sdk.connectPeer({ address: \"/ip4/127.0.0.1/tcp/8238\" });\n```\n  </Tab>\n</Tabs>\n\n### 3. Open a Payment Channel",
+      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# funding-amount is in shannons (50000000000 = 500 CKB)\ncd node1 && ./fnn-cli channel open_channel \\\n  --pubkey <node2_pubkey> \\\n  --funding-amount 50000000000 \\\n  --public true\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\n# funding_amount in hex (0xba43b7400 = 500 CKB)\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"open_channel\",\n    \"params\": [{\"pubkey\": \"<node2_pubkey>\", \"funding_amount\": \"0xba43b7400\", \"public\": true}]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// funding_amount: 0xba43b7400 = 500 CKB in shannons\nconst tempChannelId = await sdk.openChannel({\n  pubkey: \"<node2_pubkey>\",\n  fundingAmount: \"0xba43b7400\",\n  public: true,\n});\nconsole.log(\"Temporary channel ID:\", tempChannelId);\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-661",
       "title": "Basic Transfer Example",
-      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# funding-amount is in shannons (50000000000 = 500 CKB)\ncd node1 && ./fnn-cli channel open_channel \\\n  --pubkey <node2_pubkey> \\\n  --funding-amount 50000000000 \\\n  --public true\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\n# funding_amount in hex (0xba43b7400 = 500 CKB)\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"open_channel\",\n    \"params\": [{\"pubkey\": \"<node2_pubkey>\", \"funding_amount\": \"0xba43b7400\", \"public\": true}]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// funding_amount: 0xba43b7400 = 500 CKB in shannons\nconst tempChannelId = await sdk.openChannel({\n  pubkey: \"<node2_pubkey>\",\n  fundingAmount: \"0xba43b7400\",\n  public: true,\n});\nconsole.log(\"Temporary channel ID:\", tempChannelId);\n```\n  </Tab>\n</Tabs>",
+      "content": "Check channel status — wait until `state_name` becomes `ChannelReady`:\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n./fnn-cli channel list_channels\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\":\"42\",\"jsonrpc\":\"2.0\",\"method\":\"list_channels\",\"params\":[{}]}' \\\n  http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst channels = await sdk.listChannels();\nfor (const ch of channels) {\n  console.log(`${ch.channelId} — ${ch.state.stateName} — local: ${ch.localBalance}`);\n}\n```\n  </Tab>\n</Tabs>\n\n### 4. Generate an Invoice\n\nCreate a payment invoice on Node 2 for 100 CKB:",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-662",
       "title": "Basic Transfer Example",
-      "content": "Check channel status — wait until `state_name` becomes `ChannelReady`:\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n./fnn-cli channel list_channels\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\":\"42\",\"jsonrpc\":\"2.0\",\"method\":\"list_channels\",\"params\":[{}]}' \\\n  http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst channels = await sdk.listChannels();\nfor (const ch of channels) {\n  console.log(`${ch.channelId} — ${ch.state.stateName} — local: ${ch.localBalance}`);\n}\n```\n  </Tab>\n</Tabs>\n\n### 4. Generate an Invoice\n\nCreate a payment invoice on Node 2 for 100 CKB:",
+      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# amount in shannons (10000000000 = 100 CKB)\ncd node2 && ./fnn-cli --url http://127.0.0.1:8237 invoice new_invoice \\\n  --amount 10000000000 \\\n  --currency Fibt \\\n  --description \"test invoice\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\n# Generate a random payment_preimage first\npayment_preimage=\"0x$(openssl rand -hex 32)\"",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-663",
       "title": "Basic Transfer Example",
-      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# amount in shannons (10000000000 = 100 CKB)\ncd node2 && ./fnn-cli --url http://127.0.0.1:8237 invoice new_invoice \\\n  --amount 10000000000 \\\n  --currency Fibt \\\n  --description \"test invoice\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\n# Generate a random payment_preimage first\npayment_preimage=\"0x$(openssl rand -hex 32)\"",
+      "content": "curl -s -X POST -H \"Content-Type: application/json\" \\\n  -d \"{\n    \\\"id\\\": \\\"42\\\", \\\"jsonrpc\\\": \\\"2.0\\\", \\\"method\\\": \\\"new_invoice\\\",\n    \\\"params\\\": [{\n      \\\"amount\\\": \\\"0x2540be400\\\",\n      \\\"currency\\\": \\\"Fibt\\\",\n      \\\"description\\\": \\\"test invoice\\\",\n      \\\"expiry\\\": \\\"0xe10\\\",\n      \\\"payment_preimage\\\": \\\"$payment_preimage\\\",\n      \\\"hash_algorithm\\\": \\\"sha256\\\"\n    }]\n  }\" http://localhost:8237\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// amount: 0x2540be400 = 100 CKB in shannons\nconst paymentPreimage = \"0x\" + \"01\".repeat(32);\nconst { invoiceAddress } = await node2.newInvoice({\n  amount: \"0x2540be400\",\n  currency: \"Fibt\",\n  description: \"test invoice\",\n  expiry: \"0xe10\",\n  paymentPreimage,\n});\nconsole.log(\"Invoice:\", invoiceAddress);\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-664",
       "title": "Basic Transfer Example",
-      "content": "curl -s -X POST -H \"Content-Type: application/json\" \\\n  -d \"{\n    \\\"id\\\": \\\"42\\\", \\\"jsonrpc\\\": \\\"2.0\\\", \\\"method\\\": \\\"new_invoice\\\",\n    \\\"params\\\": [{\n      \\\"amount\\\": \\\"0x2540be400\\\",\n      \\\"currency\\\": \\\"Fibt\\\",\n      \\\"description\\\": \\\"test invoice\\\",\n      \\\"expiry\\\": \\\"0xe10\\\",\n      \\\"payment_preimage\\\": \\\"$payment_preimage\\\",\n      \\\"hash_algorithm\\\": \\\"sha256\\\"\n    }]\n  }\" http://localhost:8237\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// amount: 0x2540be400 = 100 CKB in shannons\nconst paymentPreimage = \"0x\" + \"01\".repeat(32);\nconst { invoiceAddress } = await node2.newInvoice({\n  amount: \"0x2540be400\",\n  currency: \"Fibt\",\n  description: \"test invoice\",\n  expiry: \"0xe10\",\n  paymentPreimage,\n});\nconsole.log(\"Invoice:\", invoiceAddress);\n```\n  </Tab>\n</Tabs>",
+      "content": "### 5. Make the Payment\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli payment send_payment --invoice \"fibt100000000001p...\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"send_payment\",\n    \"params\": [{\"invoice\": \"fibt100000000001p...\"}]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst result = await sdk.sendPayment({ invoice: invoiceAddress });\nconsole.log(\"Payment hash:\", result.paymentHash);\nconsole.log(\"Status:\", result.status);\n```\n  </Tab>\n</Tabs>\n\n### 6. Verify the Transfer\n\nCheck channel balances to confirm the transfer:",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-665",
       "title": "Basic Transfer Example",
-      "content": "### 5. Make the Payment\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli payment send_payment --invoice \"fibt100000000001p...\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"send_payment\",\n    \"params\": [{\"invoice\": \"fibt100000000001p...\"}]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst result = await sdk.sendPayment({ invoice: invoiceAddress });\nconsole.log(\"Payment hash:\", result.paymentHash);\nconsole.log(\"Status:\", result.status);\n```\n  </Tab>\n</Tabs>\n\n### 6. Verify the Transfer\n\nCheck channel balances to confirm the transfer:",
+      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# Node 1\n./fnn-cli channel list_channels\n\n# Node 2\n./fnn-cli --url http://127.0.0.1:8237 channel list_channels\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\":\"42\",\"jsonrpc\":\"2.0\",\"method\":\"list_channels\",\"params\":[{}]}' \\\n  http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// Node 1\nconst node1Channels = await sdk.listChannels();\nfor (const ch of node1Channels) {\n  console.log(`local: ${ch.localBalance}, remote: ${ch.remoteBalance}`);\n}\n\n// Node 2\nconst node2Channels = await node2.listChannels();\nfor (const ch of node2Channels) {\n  console.log(`local: ${ch.localBalance}, remote: ${ch.remoteBalance}`);\n}\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-666",
       "title": "Basic Transfer Example",
-      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# Node 1\n./fnn-cli channel list_channels\n\n# Node 2\n./fnn-cli --url http://127.0.0.1:8237 channel list_channels\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\":\"42\",\"jsonrpc\":\"2.0\",\"method\":\"list_channels\",\"params\":[{}]}' \\\n  http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// Node 1\nconst node1Channels = await sdk.listChannels();\nfor (const ch of node1Channels) {\n  console.log(`local: ${ch.localBalance}, remote: ${ch.remoteBalance}`);\n}\n\n// Node 2\nconst node2Channels = await node2.listChannels();\nfor (const ch of node2Channels) {\n  console.log(`local: ${ch.localBalance}, remote: ${ch.remoteBalance}`);\n}\n```\n  </Tab>\n</Tabs>",
+      "content": "After sending 100 CKB from Node 1, Node 1's `local_balance` decreases by ~100 CKB and `remote_balance` increases by 100 CKB.\n\n## Closing the Channel",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-667",
       "title": "Basic Transfer Example",
-      "content": "After sending 100 CKB from Node 1, Node 1's `local_balance` decreases by ~100 CKB and `remote_balance` increases by 100 CKB.\n\n## Closing the Channel",
+      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli channel shutdown_channel \\\n  --channel-id <channel_id> \\\n  --force true\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"shutdown_channel\",\n    \"params\": [{\n      \"channel_id\": \"<channel_id>\",\n      \"close_script\": {\n        \"code_hash\": \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n        \"hash_type\": \"type\",\n        \"args\": \"<your_lock_arg>\"\n      },\n      \"fee_rate\": \"0x3FC\"\n    }]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nawait sdk.shutdownChannel({\n  channelId: \"<channel_id>\",\n  force: true,\n});\nconsole.log(\"Channel closed.\");\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
       "id": "chunk-668",
       "title": "Basic Transfer Example",
-      "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli channel shutdown_channel \\\n  --channel-id <channel_id> \\\n  --force true\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"shutdown_channel\",\n    \"params\": [{\n      \"channel_id\": \"<channel_id>\",\n      \"close_script\": {\n        \"code_hash\": \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n        \"hash_type\": \"type\",\n        \"args\": \"<your_lock_arg>\"\n      },\n      \"fee_rate\": \"0x3FC\"\n    }]\n  }' http://localhost:8227\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nawait sdk.shutdownChannel({\n  channelId: \"<channel_id>\",\n  force: true,\n});\nconsole.log(\"Channel closed.\");\n```\n  </Tab>\n</Tabs>",
-      "url": "/docs/quick-start/basic-transfer",
-      "source": "docs/quick-start/basic-transfer.mdx"
-    },
-    {
-      "id": "chunk-669",
-      "title": "Basic Transfer Example",
       "content": "<Callout type=\"info\" title=\"CLI vs RPC for closing\">\nWith CLI `--force true`, `close_script` and `fee_rate` are determined automatically. With RPC, you must provide `close_script` matching your node's CKB lock script (get it from `ckb-cli account list`).\n</Callout>\n\n## Next Steps\n\n- [Transfer Stablecoins](/docs/quick-start/transfer-stablecoin) — transfer RUSD through a multi-hop path\n- [Network Resources](/docs/quick-start/network-resources) — public nodes, faucets, explorers, and more",
       "url": "/docs/quick-start/basic-transfer",
       "source": "docs/quick-start/basic-transfer.mdx"
     },
     {
-      "id": "chunk-670",
+      "id": "chunk-669",
       "title": "Multi-hop Transfers",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\nimport { Tabs, Tab } from 'fumadocs-ui/components/tabs';\n\n## TL;DR\n\nConnect your local node to Fiber's public relay nodes, open a channel, and send multi-hop payments through the Testnet. Fiber supports two routing modes: **gossip routing** (source routing, the sender builds the full path) and **trampoline routing** (the sender delegates path-finding to a relay node). Your local node does not need a public IP.\n\n```\n┌───────┐        ┌───────┐        ┌───────┐\n│ nodeA │ ─────▶ │ node1 │ ─────▶ │ node2 │\n│ local │        │public │        │public │\n└───────┘        └───────┘        └───────┘\n  sender          relay            receiver\n```\n\n## Public Node Addresses\n\n### Mainnet",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-671",
+      "id": "chunk-670",
       "title": "Multi-hop Transfers",
       "content": "| Node | Pubkey |\n|------|--------|\n| node1 | `03a8d7da8d0934363dbc17f52c872e8d833016415266eabb3527439c5dd17adc6b` |\n| node2 | `033a69e5be369dab43aefa96fa729d83c571ccb066f312136c6ab2d354fcc028f9` |\n\n### Testnet\n\n| Node | Pubkey |\n|------|--------|\n| node1 | `02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71` |\n| node2 | `0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc` |\n\n## Local Node Setup\n\n1. Download fnn from the [releases page](https://github.com/nervosnetwork/fiber/releases):\n\n   ```bash\n   mkdir tmp && cd tmp\n   tar xzvf fnn-latest.tar.gz\n   ```\n\n   <Callout type=\"info\" title=\"macOS Security\">\n   ```bash\n   xattr -d com.apple.quarantine fnn fnn-cli\n   ```\n   </Callout>\n\n2. Create account and export private key:",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-672",
+      "id": "chunk-671",
       "title": "Multi-hop Transfers",
       "content": "```bash\n   mkdir -p testnet-fnn/nodeA/ckb\n   ./ckb-cli account new           # save the lock_arg\n   ./ckb-cli account export --lock-arg <YOUR_LOCK_ARG> --extended-privkey-path ./exported-key\n   head -n 1 ./exported-key > testnet-fnn/nodeA/ckb/key\n   chmod 600 testnet-fnn/nodeA/ckb/key\n   ```\n\n3. Copy config and tools:\n\n   ```bash\n   cp config/testnet/config.yml testnet-fnn/nodeA\n   cp fnn-cli testnet-fnn/nodeA\n   ```\n\n   <Callout type=\"info\" title=\"HTTP Proxy Issues\">\n   ```bash\n   export NO_PROXY=127.0.0.1,localhost\n   ```\n   </Callout>\n\n4. Fund nodeA's address with **10,000 CKB**:\n   - CKB: [https://faucet.nervos.org](https://faucet.nervos.org)\n\n5. Start nodeA:",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-673",
+      "id": "chunk-672",
       "title": "Multi-hop Transfers",
       "content": "```bash\n   FIBER_SECRET_KEY_PASSWORD='123' RUST_LOG=info ./fnn -c testnet-fnn/nodeA/config.yml -d testnet-fnn/nodeA > testnet-fnn/nodeA/a.log 2>&1 &\n   ```\n\n## CKB Multi-Hop Payment (nodeA → node1 → node2)\n\n<Callout type=\"info\">\nCLI amounts are in shannons (1 CKB = 100,000,000). RPC amounts are hex strings (e.g. `\"0x5f5e100\"` = 100,000,000).\n</Callout>\n\n### 1. Connect to node1\n\nFirst get node1's pubkey:\n\n```bash\ncurl -s 'http://18.162.235.225:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"node_info\"}' | grep -o '\"pubkey\":\"[^\"]*\"'\n```\n\nThen connect:",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-674",
+      "id": "chunk-673",
       "title": "Multi-hop Transfers",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```bash\ncd testnet-fnn/nodeA && ./fnn-cli peer connect_peer \\\n  --pubkey 02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```bash\ncurl -s 'http://127.0.0.1:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"id\": 1, \"jsonrpc\": \"2.0\", \"method\": \"connect_peer\",\n    \"params\": [{\"pubkey\": \"<node1_pubkey>\"}]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nawait sdk.connectPeer({\n  address: \"/ip4/18.162.235.225/tcp/8119/p2p/QmXen3eUHhywmutEzydCsW4hXBoeVmdET2FJvMX69XJ1Eo\",\n});\n```\n  </Tab>\n</Tabs>\n\n### 2. Open a CKB Channel\n\n_node1's `auto_accept_min_ckb_funding_amount` is set to 400 CKB. Here we fund 500 CKB._",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-675",
+      "id": "chunk-674",
       "title": "Multi-hop Transfers",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```bash\ncd testnet-fnn/nodeA && ./fnn-cli channel open_channel \\\n  --pubkey <node1_pubkey> \\\n  --funding-amount 50000000000 \\\n  --public true\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```bash\ncurl -s 'http://127.0.0.1:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"id\": 2, \"jsonrpc\": \"2.0\", \"method\": \"open_channel\",\n    \"params\": [{\"pubkey\": \"<node1_pubkey>\", \"funding_amount\": \"0xba43b7400\", \"public\": true}]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// funding_amount: 0xba43b7400 = 500 CKB in shannons\nconst tempChannelId = await sdk.openChannel({\n  pubkey: \"<node1_pubkey>\",\n  fundingAmount: \"0xba43b7400\",\n  public: true,\n});\nconsole.log(\"Temporary channel ID:\", tempChannelId);\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-676",
+      "id": "chunk-675",
       "title": "Multi-hop Transfers",
       "content": "### 3. Wait for ChannelReady\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```bash\n./fnn-cli channel list_channels\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```bash\ncurl -s 'http://127.0.0.1:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"id\": 3, \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{\"pubkey\": \"<node1_pubkey>\"}]}'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst channels = await sdk.listChannels({ pubkey: \"<node1_pubkey>\" });\nfor (const ch of channels) {\n  console.log(`${ch.channelId} — ${ch.state.stateName}`);\n}\n```\n  </Tab>\n</Tabs>\n\n<Callout type=\"warning\">\nAfter `ChannelReady`, wait a few minutes before sending payments — the gossip protocol needs time to sync channel announcements and routing info across the network.\n</Callout>",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-677",
+      "id": "chunk-676",
       "title": "Multi-hop Transfers",
       "content": "### 4. Create an Invoice on node2\n\nGenerate a preimage: `payment_preimage=\"0x$(openssl rand -hex 32)\"`",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-678",
+      "id": "chunk-677",
       "title": "Multi-hop Transfers",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```bash\n./fnn-cli --url http://18.163.221.211:8227 invoice new_invoice \\\n  --amount 100000000 \\\n  --currency Fibt \\\n  --description \"test invoice\" \\\n  --expiry 3600 \\\n  --payment-preimage $payment_preimage\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```bash\ncurl -s 'http://18.163.221.211:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d \"{\n    \\\"id\\\": 4, \\\"jsonrpc\\\": \\\"2.0\\\", \\\"method\\\": \\\"new_invoice\\\",\n    \\\"params\\\": [{\n      \\\"amount\\\": \\\"0x5f5e100\\\",\n      \\\"currency\\\": \\\"Fibt\\\",\n      \\\"description\\\": \\\"test invoice\\\",\n      \\\"expiry\\\": \\\"0xe10\\\",\n      \\\"payment_preimage\\\": \\\"$payment_preimage\\\",\n      \\\"hash_algorithm\\\": \\\"sha256\\\"\n    }]\n  }\"\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// Create invoice on node2 (endpoint: http://18.163.221.211:8227)\nconst node2 = new FiberSDK({ endpoint: \"http://18.163.221.211:8227\" });\nconst paymentPreimage = \"0x\" + \"01\".repeat(32);\nconst { invoiceAddress } = await node2.newInvoice({\n  amount: \"0x5f5e100\",\n  currency: \"Fibt\",\n  description: \"test invoice\",\n  expiry: \"0xe10\",\n  paymentPreimage,\n  hashAlgorithm: \"sha256\",\n});\nconsole.log(\"Invoice:\", invoiceAddress);\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-679",
+      "id": "chunk-678",
       "title": "Multi-hop Transfers",
       "content": "### 5. Send Payment (nodeA → node1 → node2)\n\nFiber supports two routing modes for multi-hop payments:\n\n#### Option A: Gossip Routing (Source Routing)\n\nThe sender discovers routes via the gossip protocol and constructs the full payment path locally. No additional parameters are needed — the node automatically finds the best route to the destination.\n\n<Callout type=\"info\">\nAfter `ChannelReady`, wait a few minutes for gossip to propagate channel announcements across the network before attempting gossip-routed payments.\n</Callout>",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-680",
+      "id": "chunk-679",
       "title": "Multi-hop Transfers",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```bash\n./fnn-cli payment send_payment --invoice \"<invoice_address>\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```bash\ncurl -s 'http://127.0.0.1:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"id\": 6, \"jsonrpc\": \"2.0\", \"method\": \"send_payment\", \"params\": [{\"invoice\": \"<invoice_address>\"}]}'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst result = await sdk.sendPayment({ invoice: \"<invoice_address>\" });\nconsole.log(\"Payment hash:\", result.paymentHash);\nconsole.log(\"Status:\", result.status);\n```\n  </Tab>\n</Tabs>\n\n#### Option B: Trampoline Routing",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-681",
+      "id": "chunk-680",
       "title": "Multi-hop Transfers",
       "content": "The sender delegates route-finding to a relay node. This is useful when the sender doesn't have full network topology (e.g. a mobile wallet). Specify `trampoline_hops` with the relay node's pubkey.",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-682",
+      "id": "chunk-681",
       "title": "Multi-hop Transfers",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```bash\n./fnn-cli payment send_payment --invoice \"<invoice_address>\" \\\n  --trampoline-hops <node1_pubkey>\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```bash\ncurl -s 'http://127.0.0.1:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"id\": 6, \"jsonrpc\": \"2.0\", \"method\": \"send_payment\", \"params\": [{\"invoice\": \"<invoice_address>\", \"trampoline_hops\": [\"<node1_pubkey>\"]}]}'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst result = await sdk.sendPayment({\n  invoice: \"<invoice_address>\",\n  trampolineHops: [\"<node1_pubkey>\"],\n});\nconsole.log(\"Payment hash:\", result.paymentHash);\nconsole.log(\"Status:\", result.status);\n```\n  </Tab>\n</Tabs>\n\n### 6. Close the Channel",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-683",
+      "id": "chunk-682",
       "title": "Multi-hop Transfers",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```bash\n./fnn-cli channel shutdown_channel \\\n  --channel-id <channel_id> \\\n  --close-script '{\"code_hash\":\"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\"hash_type\":\"type\",\"args\":\"<your_lock_arg>\"}'\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```bash\ncurl -s 'http://127.0.0.1:8227' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"id\": 9, \"jsonrpc\": \"2.0\", \"method\": \"shutdown_channel\",\n    \"params\": [{\n      \"channel_id\": \"<channel_id>\",\n      \"close_script\": {\n        \"code_hash\": \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n        \"hash_type\": \"type\",\n        \"args\": \"<your_lock_arg>\"\n      },\n      \"fee_rate\": \"0x3FC\"\n    }]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nawait sdk.shutdownChannel({\n  channelId: \"<channel_id>\",\n  closeScript: {\n    codeHash: \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n    hashType: \"type\",\n    args: \"<your_lock_arg>\",\n  },\n  feeRate: \"0x3FC\",\n});\nconsole.log(\"Channel closed.\");\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/multi-hop-transfer",
       "source": "docs/quick-start/multi-hop-transfer.mdx"
     },
     {
-      "id": "chunk-684",
+      "id": "chunk-683",
       "title": "Network Resources",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\nThis page is the single source of truth for Fiber network resources. All public nodes, faucets, and tools are listed here.\n\n<Callout type=\"warning\">\n  Testnet resources may change without notice. This page is updated to reflect the current state. If you find outdated information, please [open an issue](https://github.com/nervosnetwork/fiber-docs/issues).\n</Callout>\n\n## Public Nodes\n\n### Mainnet",
       "url": "/docs/quick-start/network-resources",
       "source": "docs/quick-start/network-resources.mdx"
     },
     {
-      "id": "chunk-685",
+      "id": "chunk-684",
       "title": "Network Resources",
       "content": "| Name | Pubkey | WSS Address | Auto-accept CKB |\n|------|--------|-------------|------------------|\n| fiber-mainnet-public-ca | `03a8d7da8d0934363dbc17f52c872e8d833016415266eabb3527439c5dd17adc6b` | `/dns4/ca.fiber.channel/tcp/443/wss/p2p/QmZCfzENZqWrWwifJj9BFDvxQWFyYw5GjdB4vN7Ynd4FxY` | ≥ 499 CKB |\n| fiber-mainnet-public-tokyo | `033a69e5be369dab43aefa96fa729d83c571ccb066f312136c6ab2d354fcc028f9` | `/dns4/tokyo.fiber.channel/tcp/443/wss/p2p/QmZ73KHvZ5GFxf6XhHZ3icPeKFo93rk86kZ8qauox3avJP` | ≥ 499 CKB |\n\n### Testnet",
       "url": "/docs/quick-start/network-resources",
       "source": "docs/quick-start/network-resources.mdx"
     },
     {
-      "id": "chunk-686",
+      "id": "chunk-685",
       "title": "Network Resources",
       "content": "| Name | Pubkey | WSS Address | Auto-accept CKB | Auto-accept UDT |\n|------|--------|-------------|------------------|------------------|\n| fiber-testnet-public-bottle | `02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71` | `/dns4/bottle.fiber.channel/tcp/443/wss/p2p/QmXen3eUHhywmutEzydCsW4hXBoeVmdET2FJvMX69XJ1Eo` | ≥ 499 CKB | RUSD ≥ 20 |\n| fiber-testnet-public-bracer | `0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc` | `/dns4/bracer.fiber.channel/tcp/443/wss/p2p/QmbKyzq9qUmymW2Gi8Zq7kKVpPiNA1XUJ6uMvsUC4F3p89` | ≥ 499 CKB | RUSD ≥ 20 |\n\n<Callout type=\"info\">\n  Since v0.8.0, Fiber uses **pubkey** (hex-encoded secp256k1) for peer identification. Use `connect_peer` with the pubkey — the node will resolve the address automatically via gossip.\n</Callout>",
       "url": "/docs/quick-start/network-resources",
       "source": "docs/quick-start/network-resources.mdx"
     },
     {
-      "id": "chunk-687",
+      "id": "chunk-686",
       "title": "Network Resources",
-      "content": "## Faucets\n\n| Resource | URL | Notes |\n|----------|-----|-------|\n| CKB Testnet Faucet | [https://faucet.nervos.org](https://faucet.nervos.org) | Get testnet CKB |\n| RUSD (Stablecoin) | [https://testnet0815.stablepp.xyz/stablecoin](https://testnet0815.stablepp.xyz/stablecoin) | Mint testnet RUSD stablecoin |\n\n## Block Explorers\n\n| Resource | URL |\n|----------|-----|\n| CKB Testnet Explorer | [https://explorer.nervos.org/aggron](https://explorer.nervos.org/aggron) |\n| Fiber Network Dashboard | [https://dashboard.fiber.channel/nodes](https://dashboard.fiber.channel/nodes) |\n\n## Network Topology\n\nThe typical testnet topology for multi-hop payments:",
+      "content": "## Faucets\n\n| Resource | URL | Notes |\n|----------|-----|-------|\n| CKB Testnet Faucet | [https://faucet.nervos.org](https://faucet.nervos.org) | Get testnet CKB |\n| cWBTC Faucet | [https://faucet-cwbtc.ckb.dev](https://faucet-cwbtc.ckb.dev) | Get testnet cWBTC for CCH testing |\n| RUSD (Stablecoin) | [https://testnet0815.stablepp.xyz/stablecoin](https://testnet0815.stablepp.xyz/stablecoin) | Mint testnet RUSD stablecoin |\n\n## Block Explorers\n\n| Resource | URL |\n|----------|-----|\n| CKB Testnet Explorer | [https://explorer.nervos.org/aggron](https://explorer.nervos.org/aggron) |\n| Fiber Network Dashboard | [https://dashboard.fiber.channel/nodes](https://dashboard.fiber.channel/nodes) |\n\n## Network Topology\n\nThe typical testnet topology for multi-hop payments:",
       "url": "/docs/quick-start/network-resources",
       "source": "docs/quick-start/network-resources.mdx"
     },
     {
-      "id": "chunk-688",
+      "id": "chunk-687",
       "title": "Network Resources",
       "content": "```\n┌───────┐        ┌───────┐        ┌───────┐        ┌───────┐\n│ nodeA │ ─────▶ │ node1 │ ─────▶ │ node2 │ ─────▶ │ nodeB │\n│:8227  │        │public │        │public │        │:8237  │\n└───────┘        └───────┘        └───────┘        └───────┘\n  sender        relay node 1     relay node 2      receiver\n```\n\nLocal nodes (nodeA, nodeB) do not need to expose a public address — they connect through the public relay nodes.\n\n## Channel Capacity\n\nWhen opening a channel, each side must reserve **99 CKB** (98 CKB for commitment lock + 1 CKB for shutdown transaction fee). This reserved amount is not available for off-chain payments.",
       "url": "/docs/quick-start/network-resources",
       "source": "docs/quick-start/network-resources.mdx"
     },
     {
-      "id": "chunk-689",
+      "id": "chunk-688",
       "title": "Network Resources",
       "content": "**Example**: If you fund 499 CKB and the public node contributes 250 CKB:\n- Your available balance: 499 - 99 = **400 CKB**\n- Public node available: 250 - 99 = **151 CKB**\n\n## Node Downloads\n\nDownload the latest Fiber Node binary from the [GitHub Releases page](https://github.com/nervosnetwork/fiber/releases).\n\n## Getting Help\n\n- [GitHub Issues](https://github.com/nervosnetwork/fiber/issues) — bug reports and feature requests\n- [Fiber Documentation](/docs) — full documentation",
       "url": "/docs/quick-start/network-resources",
       "source": "docs/quick-start/network-resources.mdx"
     },
     {
-      "id": "chunk-690",
+      "id": "chunk-689",
       "title": "Run a Native Node (Docker)",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\n## TL;DR\n\nPull the image, mount a data directory with your CKB private key, and start the container. In under a minute you'll have a Fiber node running on Testnet — no Rust toolchain required.\n\n```bash\ndocker run --rm -d \\\n  --name fiber-node \\\n  -e FIBER_SECRET_KEY_PASSWORD='YOUR_PASSWORD' \\\n  -v \"$(pwd)/fiber-node:/fiber\" \\\n  -p 8228:8228 \\\n  nervos/fiber:0.9.0-rc7\n```\n\n## Prerequisites\n\n- [Docker](https://docs.docker.com/get-docker/) (v20.10 or newer) installed and running\n- A CKB private key (generate one with [`ckb-cli`](https://github.com/nervosnetwork/ckb-cli) or export from an existing wallet)\n- Basic understanding of command line operations\n\n## Running Your Node\n\n### 1. Pull the Docker Image",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-691",
+      "id": "chunk-690",
       "title": "Run a Native Node (Docker)",
       "content": "The Fiber image is published to two registries:\n\n| Registry | Image | |\n|----------|-------|-|\n| Docker Hub | `nervos/fiber:<release-tag>` | Default, widely used |\n| GitHub Container Registry | `ghcr.io/nervosnetwork/fiber:<release-tag>` | Alternative if Docker Hub is unavailable |\n\n```bash\n# From Docker Hub\ndocker pull nervos/fiber:0.9.0-rc7\n\n# Or from GHCR\ndocker pull ghcr.io/nervosnetwork/fiber:0.9.0-rc7\n```\n\nCheck [Docker Hub](https://hub.docker.com/r/nervos/fiber/tags) or [GHCR](https://github.com/nervosnetwork/fiber/pkgs/container/fiber) for available tags. For production, pin a specific version tag (e.g. `0.9.0-rc7`) to avoid unexpected upgrades.\n\n### 2. Prepare the Data Directory\n\nCreate a local directory to hold the node's configuration, database, and key material:",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-692",
+      "id": "chunk-691",
       "title": "Run a Native Node (Docker)",
       "content": "```bash\nmkdir -p ./fiber-node/ckb\n```\n\nPlace your CKB private key at `./fiber-node/ckb/key`. If you already have a key exported by `ckb-cli`, copy the first line of the extended privkey file:\n\n```bash\nhead -n 1 ./ckb/exported-key > ./fiber-node/ckb/key\n```\n\n<Callout type=\"info\" title=\"Private Key Format\">\nThe key file must contain a **raw 64-character hex string WITHOUT the `0x` prefix**. If you are using a key exported by `ckb-cli`, make sure to remove the `0x` prefix before saving it to `./fiber-node/ckb/key`.\n</Callout>",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-693",
+      "id": "chunk-692",
       "title": "Run a Native Node (Docker)",
       "content": "<Callout type=\"info\" title=\"First-Run Behavior\">\nIf no `config.yml` exists in the data directory on first start, the container automatically copies the bundled Testnet configuration template. You can then edit `./fiber-node/config.yml` and restart the container to apply changes.\n</Callout>\n\n### 3. Run the Container\n\nStart the node with the following command:\n\n```bash\nmkdir -p ./fiber-node/ckb\n# Place your CKB private key in ./fiber-node/ckb/key\n\ndocker run --rm -it \\\n  --name fiber-node \\\n  -e FIBER_SECRET_KEY_PASSWORD='YOUR_PASSWORD' \\\n  -e RUST_LOG='info' \\\n  -v \"$(pwd)/fiber-node:/fiber\" \\\n  -p 8228:8228 \\\n  nervos/fiber:0.9.0-rc7\n```",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-694",
+      "id": "chunk-693",
       "title": "Run a Native Node (Docker)",
       "content": "| Port | Purpose | Exposure |\n|------|---------|----------|\n| `8228` | P2P networking | Mapped to the host; must be reachable for public nodes |\n| `8227` | JSON-RPC | Listens on `127.0.0.1` inside the container by default (not mapped) |\n\n> **Expected Output:** You should see log lines indicating the node is starting, connecting to bootnodes, and syncing with the Testnet. Press `Ctrl+C` to stop the node (add `-d` instead of `-it` to run in detached mode).\n\n<Callout type=\"info\" title=\"Key Auto-Encryption on First Run\">\nOn first run, the node will automatically encrypt the plaintext key file using the password provided via `FIBER_SECRET_KEY_PASSWORD`. After this, the `ckb/key` file will be in encrypted binary format. This is normal and expected behavior.\n</Callout>\n\n### 4. Environment Variables",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-695",
+      "id": "chunk-694",
       "title": "Run a Native Node (Docker)",
       "content": "The container reads its configuration through the following environment variables:\n\n| Variable | Description | Required |\n|----------|-------------|----------|\n| `FIBER_SECRET_KEY_PASSWORD` | Password to encrypt/decrypt the CKB private key | Yes |\n| `RUST_LOG` | Log level (e.g. `info`, `debug`) | No |\n| `FIBER_CONFIG_TEMPLATE` | Path to config template inside container | No |\n| `FIBER_CONFIG` | Path to custom config file | No |\n| `FIBER_HOME` | Base directory (default: `/fiber`) | No |\n\n### 5. Use Mainnet Configuration\n\nBy default the container starts on Testnet. To run on Mainnet, point `FIBER_CONFIG_TEMPLATE` to the bundled mainnet template:",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-696",
+      "id": "chunk-695",
       "title": "Run a Native Node (Docker)",
       "content": "```bash\ndocker run --rm -it \\\n  --name fiber-node \\\n  -e FIBER_SECRET_KEY_PASSWORD='YOUR_PASSWORD' \\\n  -e FIBER_CONFIG_TEMPLATE='/usr/local/share/fiber/config/mainnet/config.yml' \\\n  -v \"$(pwd)/fiber-node:/fiber\" \\\n  -p 8228:8228 \\\n  nervos/fiber:0.9.0-rc7\n```\n\n<Callout type=\"info\">\nOn first run with the mainnet template, a `config.yml` is generated from the template in the data directory. Review and adjust the CKB RPC endpoint and other settings before funding channels with real value.\n</Callout>\n\n### 6. Interact with the Node\n\nUse `docker exec` to run `fnn-cli` commands inside the running container:\n\n```bash\n# Check node info\ndocker exec -it fiber-node fnn-cli info\n\n# List channels\ndocker exec -it fiber-node fnn-cli channel list_channels",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-697",
+      "id": "chunk-696",
       "title": "Run a Native Node (Docker)",
       "content": "# Interactive mode\ndocker exec -it fiber-node fnn-cli\n```\n\n### 7. Expose RPC (Advanced)\n\nBy default the RPC endpoint listens on `127.0.0.1:8227` inside the container and is not mapped to the host. If you need external access, edit `config.yml` in your data directory to set `rpc.listening_addr` to `0.0.0.0:8227`, then map the port when starting the container:\n\n```bash\ndocker run --rm -it \\\n  --name fiber-node \\\n  -e FIBER_SECRET_KEY_PASSWORD='YOUR_PASSWORD' \\\n  -v \"$(pwd)/fiber-node:/fiber\" \\\n  -p 8228:8228 \\\n  -p 8227:8227 \\\n  nervos/fiber:0.9.0-rc7\n```\n\nOnce the RPC port is mapped, you can call the JSON-RPC interface directly from the host:\n\n```bash\ncurl -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"node_info\"}' \\\n  http://127.0.0.1:8227/\n```",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-698",
+      "id": "chunk-697",
       "title": "Run a Native Node (Docker)",
       "content": "<Callout type=\"warning\" title=\"Security Risk\">\nExposing the RPC port to the public internet allows anyone to control your node — including opening channels, sending payments, and accessing your keys. Only map port `8227` on a trusted network, or protect it with a reverse proxy that adds authentication and TLS.\n</Callout>\n\n### 8. Build the Image Locally\n\nIf you want to build from source — for example to test an unreleased branch — clone the repository and build the image:\n\n```bash\ngit clone https://github.com/nervosnetwork/fiber.git\ncd fiber\ndocker build -f docker/Dockerfile -t fiber:local .\n```\n\nThen run the locally built image using `fiber:local` instead of `nervos/fiber:0.9.0-rc7`.\n\n### 9. Data Migration",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-699",
+      "id": "chunk-698",
       "title": "Run a Native Node (Docker)",
       "content": "When upgrading from older versions that require explicit storage migration, run the migration tool against your data directory:\n\n```bash\ndocker run --rm -it \\\n  -v \"$(pwd)/fiber-node:/fiber\" \\\n  nervos/fiber:<0.8.x-release-tag> \\\n  fnn-migrate -d /fiber\n```\n\nReplace `<0.8.x-release-tag>` with the exact version you are upgrading from (no `v` prefix, e.g. `0.8.0`). After migration completes, start the node with the new image as usual.\n\n<Callout type=\"info\">\nStarting from 0.9.0-rc1, storage migration is handled automatically by FNN on startup. No separate migration step is needed when upgrading between 0.9.x releases.\n</Callout>\n\n## Next Steps",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-700",
+      "id": "chunk-699",
       "title": "Run a Native Node (Docker)",
       "content": "- [Basic Transfer](/docs/quick-start/basic-transfer) — send your first payment\n- [Config Reference](/docs/guide/node-operator/config-reference) — full configuration options",
       "url": "/docs/quick-start/run-a-node/docker",
       "source": "docs/quick-start/run-a-node/docker.mdx"
     },
     {
-      "id": "chunk-701",
+      "id": "chunk-700",
       "title": "Run a WASM Node",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\n## TL;DR\n\nUse `@nervosnetwork/fiber-js` to run a Fiber node inside a browser app. Install the package, serve a Fiber YAML config, create a `Fiber` instance on a cross-origin isolated page, and call `start()`; application code should not depend on the internal `fiber-wasm` package directly.",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-702",
+      "id": "chunk-701",
       "title": "Run a WASM Node",
       "content": "<div className=\"not-prose my-8 rounded-2xl border border-fd-border bg-fd-card p-6\">\n  <p className=\"mb-2 text-sm font-medium uppercase tracking-widest text-fd-muted-foreground\">Interactive Quick Start</p>\n  <h2 className=\"mb-3 text-2xl font-semibold\">Run a real Fiber node in this browser</h2>\n  <p className=\"mb-6 max-w-2xl text-fd-muted-foreground\">Start Fiber WASM, complete a real WSS peer handshake, derive this browser's Testnet CKB address, open a channel, and send a keysend payment. The lab is isolated from the docs page because Fiber WASM requires SharedArrayBuffer.</p>\n  <a className=\"inline-flex rounded-full bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-neutral-200\" href=\"/labs/browser-node\">Open Browser Node Lab →</a>\n</div>",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-703",
+      "id": "chunk-702",
       "title": "Run a WASM Node",
       "content": "## Try It Before You Integrate It\n\nThe lab runs the node locally in your browser; it is not a UI that remotely controls a hosted Fiber node. Browsers cannot open raw TCP sockets, so the WASM node connects outbound to a native public node through WSS:\n\n```text\nYour browser                      Fiber Testnet\n┌──────────────────────┐          ┌──────────────────────────┐\n│ Fiber WASM node      │   WSS    │ Public native node       │\n│ IndexedDB state      │ ───────► │ Payment channel peer     │\n│ Browser-local key    │          │ Fiber network            │\n└──────────────────────┘          └──────────────────────────┘\n```\n\nThe interactive flow uses `fiber-testnet-public-bottle` from [Network Resources](/docs/quick-start/network-resources). It verifies each stage with live SDK state:",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-704",
+      "id": "chunk-703",
       "title": "Run a WASM Node",
       "content": "1. Start the WASM node and wait until `listPeers()` confirms the WSS handshake.\n2. Display the browser node's CKB address and query its Testnet balance.\n3. Fund that address and open a real Testnet channel with the public node.\n4. Enter an amount and send an invoice-free keysend payment after the channel reaches `Ready`.",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-705",
+      "id": "chunk-704",
       "title": "Run a WASM Node",
       "content": "<Callout type=\"warning\" title=\"Testnet identity and funding\">\nThe lab stores one Testnet identity in the current browser so the funding address survives refreshes. Different browser profiles receive different addresses, and clearing site data creates a new one. Do not send Mainnet funds to the lab address. The public node's current channel threshold is listed in [Network Resources](/docs/quick-start/network-resources), and additional CKB is required for transaction fees.\n</Callout>\n\n## What is fiber-js?\n\n`fiber-js` is a JavaScript/TypeScript wrapper around the Fiber WebAssembly (WASM) node. It runs in browser-based applications and provides common Fiber node operations without running a separate backend service.",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-706",
+      "id": "chunk-705",
       "title": "Run a WASM Node",
       "content": "| | Native Node | WASM Node |\n|---|---|---|\n| **Runtime** | Native binary | Browser |\n| **Deployment** | Server or local machine | Embedded in web app |\n| **Public IP required** | Yes | No, use outbound `/ws/` or `/wss/` peers |\n| **Storage** | File system (SQLite/RocksDB) | IndexedDB (via WASM worker) |\n| **Use case** | Production node operators | Browser wallets, web games, client-side dApps |\n\n## Prerequisites\n\nYou need a JavaScript development environment before using `fiber-js`:\n\n- [Node.js](https://nodejs.org/) with `npm`\n- A browser-oriented build tool or framework, such as Vite, Next.js, Webpack 5, or an equivalent ESM toolchain\n\nThe examples below use `npm`. If your project already uses `pnpm`, use the equivalent `pnpm` command.\n\n## Installation",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-707",
+      "id": "chunk-706",
       "title": "Run a WASM Node",
       "content": "```bash\nnpm install @nervosnetwork/fiber-js\n# or\npnpm add @nervosnetwork/fiber-js\n```\n\nPrepare a YAML config from the Fiber source tree. For local docs development with `fiber` checked out next to `fiber-docs`:\n\n```bash\nmkdir -p public/fiber-config\ncp ../fiber/config/testnet/config.yml public/fiber-config/testnet.yml\n```\n\nYou can also download the config from the Fiber repository and serve it from any static path in your app.\n\n<Callout type=\"warn\" title=\"Browser requirements\">\n`new Fiber()` creates `SharedArrayBuffer` objects immediately. Only create a `Fiber` instance on a cross-origin isolated page, and make sure your deployment serves WASM and worker assets with the required CORS and isolation headers.\n</Callout>\n\n## Quick Start",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-708",
+      "id": "chunk-707",
       "title": "Run a WASM Node",
       "content": "```ts\nimport { Fiber, randomSecretKey } from \"@nervosnetwork/fiber-js\";\n\nif (!crossOriginIsolated) {\n  throw new Error(\"fiber-js requires a cross-origin isolated page.\");\n}\n\n// 1. Create the Fiber WASM node wrapper.\nconst fiber = new Fiber();\n\n// 2. Load the same YAML config format used by fnn.\nconst network = \"testnet\";\nconst configPath = `/fiber-config/${network}.yml`;\nconst config = await fetch(configPath).then((response) => {\n  if (!response.ok) {\n    throw new Error(`Failed to load Fiber config: ${configPath}`);\n  }\n\n  return response.text();\n});\n\n// 3. Start the node. Persist these keys in real applications.\nconst fiberKeyPair = randomSecretKey();\nconst ckbSecretKey = randomSecretKey();\nconst databasePrefix = `${network}:demo`;",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-709",
+      "id": "chunk-708",
       "title": "Run a WASM Node",
       "content": "await fiber.start(\n  config,\n  fiberKeyPair,\n  ckbSecretKey,\n  undefined,\n  \"info\",\n  databasePrefix,\n);\n\n// 4. Query node state.\nconst info = await fiber.nodeInfo();\nconsole.log(\"Node started:\", info);\nconsole.log(\"Connected peers:\", await fiber.listPeers());\n```\n\n> **Expected Output:** The node initializes, connects to configured `/ws/` or `/wss/` peers, and starts syncing. `nodeInfo()` returns your node's pubkey, version, and chain info.\n\n## Common Workflows\n\n### Open a Channel and Send a Payment\n\nReplace `peerPubkey` and `peerAddress` with values for the same target peer. `openChannel()` requires the CKB secret key passed to `start()` to control spendable CKB. Browser wallet integrations usually use `openChannelWithExternalFunding()` instead.",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-710",
+      "id": "chunk-709",
       "title": "Run a WASM Node",
       "content": "```ts\nconst toRpcHex = (value: bigint): `0x${string}` =>\n  `0x${value.toString(16)}` as `0x${string}`;\nconst ckb = (amount: bigint): `0x${string}` => toRpcHex(amount * 100_000_000n);\nconst randomHash = (): `0x${string}` => {\n  const bytes = crypto.getRandomValues(new Uint8Array(32));\n  return `0x${Array.from(bytes)\n    .map((byte) => byte.toString(16).padStart(2, \"0\"))\n    .join(\"\")}` as `0x${string}`;\n};\n\nconst peerPubkey = \"<peer_pubkey>\";\nconst peerAddress = \"<peer_wss_multiaddr>\";\n\n// Connect to a browser-reachable peer.\nawait fiber.connectPeer({\n  address: peerAddress,\n  save: true,\n});\n\n// Open a channel. The amount is a CKB RPC hex string in shannons.\nawait fiber.openChannel({\n  pubkey: peerPubkey,\n  funding_amount: ckb(499n),\n  public: true,\n});",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-711",
+      "id": "chunk-710",
       "title": "Run a WASM Node",
       "content": "// Create an invoice on the receiving node.\nconst invoice = await fiber.newInvoice({\n  amount: ckb(1n),\n  currency: \"Fibt\",\n  description: \"Test payment\",\n  payment_preimage: randomHash(),\n});\n\n// Send the payment.\nawait fiber.sendPayment({ invoice: invoice.invoice_address });\n```\n\n### Keysend (No Invoice)\n\n```ts\nawait fiber.sendPayment({\n  target_pubkey: \"<recipient_pubkey>\",\n  amount: ckb(1n),\n  keysend: true,\n});\n```\n\n## Error Handling\n\n```ts\ntry {\n  const result = await fiber.sendPayment({ invoice: \"fibt1...\" });\n} catch (err) {\n  console.error(\"Payment failed:\", err);\n}\n```",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-712",
+      "id": "chunk-711",
       "title": "Run a WASM Node",
       "content": "Common errors:\n- **`fiber-js requires a cross-origin isolated page`**: serve the page with isolation headers before calling `new Fiber()`.\n- **Fiber is not started**: `await fiber.start(...)` before invoking node methods.\n- **Connection failures**: browser nodes usually need remote `/ws/` or `/wss/` peer addresses, not plain `/tcp/` addresses.\n- **Configuration errors**: check that the loaded YAML config matches the target network and includes browser-reachable bootnodes.\n\n## API Reference\n\n`@nervosnetwork/fiber-js` exports the `Fiber` class. Its methods are camelCase wrappers around Fiber RPC commands, and async methods return promises that reject on command errors.",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-713",
+      "id": "chunk-712",
       "title": "Run a WASM Node",
       "content": "| Area | Key Methods |\n|--------|--------------|\n| **Lifecycle** | `start`, `stop`, `invokeCommand` |\n| **Channel** | `openChannel`, `openChannelWithExternalFunding`, `submitSignedFundingTx`, `listChannels`, `shutdownChannel`, `updateChannel` |\n| **Payment** | `sendPayment`, `getPayment`, `buildRouter`, `sendPaymentWithRouter` |\n| **Invoice** | `newInvoice`, `parseInvoice`, `getInvoice`, `cancelInvoice` |\n| **Peer** | `connectPeer`, `disconnectPeer`, `listPeers` |\n| **Graph** | `graphNodes`, `graphChannels` |\n| **Node** | `nodeInfo` |\n\nFor the full API reference see [Build -> js](/docs/build/sdk/js).\n\n## Next Steps",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-714",
+      "id": "chunk-713",
       "title": "Run a WASM Node",
       "content": "- [Open Browser Node Lab](/labs/browser-node) — run the complete browser flow\n- [Basic Transfer](/docs/quick-start/basic-transfer) — learn the channel and payment flow\n- [JavaScript Overview](/docs/build/sdk/js) — browser runtime, security headers, and API details\n- [Build a Game with Fiber](/docs/build/simple-game) — end-to-end example with Fiber payments",
       "url": "/docs/quick-start/run-a-node/fiberjs",
       "source": "docs/quick-start/run-a-node/fiberjs.mdx"
     },
     {
-      "id": "chunk-715",
+      "id": "chunk-714",
       "title": "Overview",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\nA **Fiber node** is a running instance of the [Fiber Network Node (FNN)](https://github.com/nervosnetwork/fiber) — the reference implementation of the Fiber Network Protocol (FNP). In practical terms, it is the software that connects you to the Fiber peer-to-peer payment network, manages payment channels, routes multi-hop payments, and signs the on-chain transactions that anchor channel state to CKB.\n\nIf you want to **send or receive** payments over Fiber, build a wallet that speaks the protocol, or **earn routing fees** by forwarding payments for others, you need a node.",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
-      "id": "chunk-716",
+      "id": "chunk-715",
       "title": "Overview",
       "content": "<Callout type=\"info\">\nFNN is still under active development. Before upgrading between versions, close your channels or migrate storage carefully — protocol and storage formats can change between releases.\n</Callout>\n\n## What a Fiber Node Does\n\nRunning a node gives you a local view of the Fiber network and the ability to:",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
-      "id": "chunk-717",
+      "id": "chunk-716",
       "title": "Overview",
       "content": "- **Maintain payment channels** — open, update, and close channels with other nodes.\n- **Send and receive payments** — both direct peer payments and multi-hop routed payments.\n- **Swap assets** — move value across CKB-native assets (CKB and whitelisted UDTs such as RUSD) and across networks (e.g., between Lightning and Fiber via cross-chain constructs).\n- **Route payments** — forward payments for others and collect routing fees if you run a well-connected public node.\n- **Gossip with the network** — discover peers, channels, and fee policies through the P2P protocol.",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
-      "id": "chunk-718",
+      "id": "chunk-717",
       "title": "Overview",
       "content": "All of this happens through a JSON-RPC interface (and an optional CLI wrapper). The node itself is responsible for channel state management, `HTLC`/`PTLC`-style locking, and publishing the correct on-chain settlement transaction when a channel closes.\n\n## Node Forms\n\nFiber ships in two forms. The right one depends on where you want to run it and who controls the runtime.\n\n### Native Node (`fnn`)\n\nThe native Rust binary is the full production node. It runs as a standalone process on a server or local machine, stores channel state locally (RocksDB or SQLite), and exposes JSON-RPC on `127.0.0.1:8227` by default.",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
-      "id": "chunk-719",
+      "id": "chunk-718",
       "title": "Overview",
-      "content": "| Aspect | Details |\n|--------|---------|\n| **Runtime** | Native binary (Linux, macOS, Windows) |\n| **Best for** | Routing nodes, production services, server deployments |\n| **Storage** | Local RocksDB/SQLite database |\n| **Network exposure** | Public IP recommended for routing; private nodes can connect through public relay nodes |\n| **Interaction** | `fnn-cli` or raw JSON-RPC |\n\nUse the native node when you need full control, persistent storage, and the ability to accept inbound channel requests from the public internet.\n\n→ [Run a Native Node](/docs/quick-start/run-a-node/rust)\n\n### Deploy the Native Node with Docker",
+      "content": "| Aspect | Details |\n|--------|---------|\n| **Runtime** | Native binary (Linux, macOS, Windows) |\n| **Best for** | Routing nodes, production services, server deployments |\n| **Storage** | Local RocksDB/SQLite database |\n| **Network exposure** | Public IP recommended for routing; private nodes can connect through public relay nodes |\n| **Interaction** | `fnn-cli` or raw JSON-RPC |\n\nUse the native node when you need full control, persistent storage, and the ability to accept inbound channel requests from the public internet. A guided installer is being prepared to download the release bundle, configure the selected network, set up keys, and generate a reusable startup script.\n\n→ [Run a Native Node](/docs/quick-start/run-a-node/rust)\n\n### Deploy the Native Node with Docker",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
-      "id": "chunk-720",
+      "id": "chunk-719",
       "title": "Overview",
       "content": "If you prefer not to install the Rust toolchain or compile from source, you can deploy the same native `fnn` binary using the official Docker image. A single `docker run` command gives you a fully functional native node — it mounts a local data directory for configuration, keys, and channel state, and exposes the P2P and RPC ports just like a locally built binary.\n\n| Aspect | Details |\n|--------|--------|\n| **Runtime** | Docker container (Linux, macOS, Windows) |\n| **Best for** | Quick native node deployment without build tools, CI/CD pipelines |\n| **Storage** | Mounted local volume (RocksDB/SQLite) |\n| **Network exposure** | Public IP recommended for routing; private nodes can connect through public relay nodes |\n| **Interaction** | `docker exec fnn-cli` or raw JSON-RPC |",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
-      "id": "chunk-721",
+      "id": "chunk-720",
       "title": "Overview",
       "content": "Use Docker when you want a fast, reproducible native node deployment without installing build dependencies — ideal for server setups and automated environments.\n\n→ [Run a Native Node (Docker)](/docs/quick-start/run-a-node/docker)\n\n### WASM Node (`fiber-js`)\n\n`fiber-js` compiles the same node logic to WebAssembly so it can run inside a browser or a `Node.js` process. It stores data in IndexedDB (via a WASM worker) and is designed for client-side applications that do not want to operate a backend server.",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
-      "id": "chunk-722",
+      "id": "chunk-721",
       "title": "Overview",
       "content": "| Aspect | Details |\n|--------|---------|\n| **Runtime** | Browser or `Node.js` |\n| **Best for** | Browser wallets, web games, client-side dApps |\n| **Storage** | IndexedDB |\n| **Network exposure** | No public IP required; can connect through relay nodes |\n| **Interaction** | JavaScript/TypeScript API (`fiber-js` package) |\n\nUse the WASM node when you want users to bring their own node inside a web app, without asking them to install or host server software.\n\n→ [Run a WASM Node](/docs/quick-start/run-a-node/fiberjs)\n\n## Deployment Scenarios\n\n### Local / Testnet Node",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
+      "id": "chunk-722",
+      "title": "Overview",
+      "content": "The fastest way to experiment. You run `fnn` locally against Fiber Testnet, fund the address from a testnet faucet, and open channels with the public Testnet relay nodes. No public IP is required because you initiate outbound connections to the public nodes.\n\nTypical flow with the upcoming installer:\n\n1. Bootstrap the FNN bundle, `ckb-cli`, and Testnet configuration.\n2. Run the guided setup to create or import a CKB account.\n3. Save `FIBER_SECRET_KEY_PASSWORD` and back up the install directory.\n4. Start the node with the generated `start-node` script.\n5. Open a channel and try [Basic Transfer](/docs/quick-start/basic-transfer).\n\nUntil a Fiber release includes the installer, follow the release-only manual path in [Run a Native Node](/docs/quick-start/run-a-node/rust#manual-installation).",
+      "url": "/docs/quick-start/run-a-node/index",
+      "source": "docs/quick-start/run-a-node/index.mdx"
+    },
+    {
       "id": "chunk-723",
       "title": "Overview",
-      "content": "The fastest way to experiment. You run `fnn` locally against Fiber Testnet, fund the address from a testnet faucet, and open channels with the public Testnet relay nodes. No public IP is required because you initiate outbound connections to the public nodes.\n\nTypical flow:\n\n1. Download or build the `fnn` binary.\n2. Generate or export a CKB private key.\n3. Copy `config/testnet/config.yml` and set `FIBER_SECRET_KEY_PASSWORD`.\n4. Start the node and connect to a public Testnet node.\n5. Open a channel and try [Basic Transfer](/docs/quick-start/basic-transfer).\n\n### Production Public Node\n\nA public node has a reachable P2P address (default port `8228`) and is advertised in the network graph. Other nodes can connect to it and open channels. This is the form you want if you intend to:",
+      "content": "### Production Public Node\n\nA public node has a reachable P2P address (default port `8228`) and is advertised in the network graph. Other nodes can connect to it and open channels. This is the form you want if you intend to:\n\n- Accept inbound channels from users.\n- Route multi-hop payments and earn fees.\n- Provide liquidity as a service.\n\nYou will need:\n\n- A stable server with a public IP.\n- A trusted CKB RPC endpoint (especially important on Mainnet).\n- Sufficient CKB/UDT liquidity to fund and maintain channels.\n- (Optional) A TLS proxy if you also want browser/WASM clients to reach you over WSS.\n\n→ See [WSS Configuration](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc5/docs/fiber-node-wss.md) for browser-facing deployments.\n\n### Private Node Behind Relay",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
       "id": "chunk-724",
       "title": "Overview",
-      "content": "- Accept inbound channels from users.\n- Route multi-hop payments and earn fees.\n- Provide liquidity as a service.\n\nYou will need:\n\n- A stable server with a public IP.\n- A trusted CKB RPC endpoint (especially important on Mainnet).\n- Sufficient CKB/UDT liquidity to fund and maintain channels.\n- (Optional) A TLS proxy if you also want browser/WASM clients to reach you over WSS.\n\n→ See [WSS Configuration](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc5/docs/fiber-node-wss.md) for browser-facing deployments.\n\n### Private Node Behind Relay",
+      "content": "Not every node has to be public. A private node can open outbound channels to public relay nodes and then send or receive payments through those relays. This is the easiest way to participate without exposing a public IP or running server infrastructure.\n\nThis pattern is covered in the [Public Nodes User Manual](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc5/docs/public-nodes.md) and is the default mental model for the WASM node.\n\n### Browser-Embedded Node\n\nWith `fiber-js`, a Fiber node can live inside a web page. Application code creates a `Fiber` instance and starts it with `fiber.start(config, fiberKeyPair, ckbSecretKey, ...)`; the node can then connect to Testnet bootnodes over WebSocket. This is ideal for wallets, games, and demos where installation friction must be minimal.",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
       "id": "chunk-725",
       "title": "Overview",
-      "content": "Not every node has to be public. A private node can open outbound channels to public relay nodes and then send or receive payments through those relays. This is the easiest way to participate without exposing a public IP or running server infrastructure.\n\nThis pattern is covered in the [Public Nodes User Manual](https://github.com/nervosnetwork/fiber/blob/v0.9.0-rc5/docs/public-nodes.md) and is the default mental model for the WASM node.\n\n### Browser-Embedded Node\n\nWith `fiber-js`, a Fiber node can live inside a web page. Application code creates a `Fiber` instance and starts it with `fiber.start(config, fiberKeyPair, ckbSecretKey, ...)`; the node can then connect to Testnet bootnodes over WebSocket. This is ideal for wallets, games, and demos where installation friction must be minimal.",
+      "content": "→ [Run a WASM Node](/docs/quick-start/run-a-node/fiberjs)\n\n## Mainnet vs. Testnet\n\nFiber supports both Mainnet and Testnet deployments. The network is selected in `config.yml` via the `fiber.chain` field.\n\n| Network | Purpose | CKB RPC Default | Notes |\n|---------|---------|-----------------|-------|\n| **Testnet** | Development and experimentation | `https://testnet.ckbapp.dev/` | Free testnet CKB and RUSD available from faucets |\n| **Mainnet** | Production value transfer | Your own trusted CKB node or a trusted RPC provider | Public nodes exist, but always verify liquidity and policies |\n\nTestnet is the recommended place to start. Once you are comfortable with channel management, payment flows, and backup procedures, move the same setup to Mainnet.\n\n## Before You Start",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
       "id": "chunk-726",
       "title": "Overview",
-      "content": "→ [Run a WASM Node](/docs/quick-start/run-a-node/fiberjs)\n\n## Mainnet vs. Testnet\n\nFiber supports both Mainnet and Testnet deployments. The network is selected in `config.yml` via the `fiber.chain` field.\n\n| Network | Purpose | CKB RPC Default | Notes |\n|---------|---------|-----------------|-------|\n| **Testnet** | Development and experimentation | `https://testnet.ckbapp.dev/` | Free testnet CKB and RUSD available from faucets |\n| **Mainnet** | Production value transfer | Your own trusted CKB node or a trusted RPC provider | Public nodes exist, but always verify liquidity and policies |\n\nTestnet is the recommended place to start. Once you are comfortable with channel management, payment flows, and backup procedures, move the same setup to Mainnet.\n\n## Before You Start",
+      "content": "At a minimum, you need a **CKB private key**. The native installer can download `ckb-cli` and guide you through creating or importing an account; manual and Docker setups can use an existing key exported from a CKB wallet.\n\nThe detailed prerequisites — CKB RPC endpoints, `config.yml`, how much CKB to reserve, and whether a one-way channel lets the other side join without depositing CKB — are covered in the native ([installer or manual setup](/docs/quick-start/run-a-node/rust) or [Docker](/docs/quick-start/run-a-node/docker)) and [WASM](/docs/quick-start/run-a-node/fiberjs) guides.\n\n<Callout type=\"warning\">\nKeep your node data directory, especially `fiber/store` and the `ckb/key` file, backed up and secure. Losing channel state can mean losing funds.\n</Callout>\n\n## Choose Your Path",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
       "id": "chunk-727",
       "title": "Overview",
-      "content": "At a minimum, you need a **CKB private key**. You can generate one with [`ckb-cli`](https://github.com/nervosnetwork/ckb-cli) or export it from a CKB wallet.\n\nThe detailed prerequisites — CKB RPC endpoints, `config.yml`, how much CKB to reserve, and whether a one-way channel lets the other side join without depositing CKB — are covered in the native ([build from source](/docs/quick-start/run-a-node/rust) or [Docker](/docs/quick-start/run-a-node/docker)) and [WASM](/docs/quick-start/run-a-node/fiberjs) guides.\n\n<Callout type=\"warning\">\nKeep your node data directory, especially `fiber/store` and the `ckb/key` file, backed up and secure. Losing channel state can mean losing funds.\n</Callout>\n\n## Choose Your Path",
+      "content": "| I want to... | Recommended node |\n|--------------|------------------|\n| Run a routing node and earn fees | [Native Node](/docs/quick-start/run-a-node/rust) ([or via Docker](/docs/quick-start/run-a-node/docker)) |\n| Build a server-side payment service | [Native Node](/docs/quick-start/run-a-node/rust) ([or via Docker](/docs/quick-start/run-a-node/docker)) |\n| Add Fiber to a browser wallet or web game | [WASM Node](/docs/quick-start/run-a-node/fiberjs) |\n| Try Fiber without hosting infrastructure | [WASM Node](/docs/quick-start/run-a-node/fiberjs) or Native Node behind public relays |\n| Learn the protocol locally | [Native Node on Testnet](/docs/quick-start/run-a-node/rust) |",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
       "id": "chunk-728",
       "title": "Overview",
-      "content": "| I want to... | Recommended node |\n|--------------|------------------|\n| Run a routing node and earn fees | [Native Node](/docs/quick-start/run-a-node/rust) ([or via Docker](/docs/quick-start/run-a-node/docker)) |\n| Build a server-side payment service | [Native Node](/docs/quick-start/run-a-node/rust) ([or via Docker](/docs/quick-start/run-a-node/docker)) |\n| Add Fiber to a browser wallet or web game | [WASM Node](/docs/quick-start/run-a-node/fiberjs) |\n| Try Fiber without hosting infrastructure | [WASM Node](/docs/quick-start/run-a-node/fiberjs) or Native Node behind public relays |\n| Learn the protocol locally | [Native Node on Testnet](/docs/quick-start/run-a-node/rust) |",
-      "url": "/docs/quick-start/run-a-node/index",
-      "source": "docs/quick-start/run-a-node/index.mdx"
-    },
-    {
-      "id": "chunk-729",
-      "title": "Overview",
       "content": "After you have a node running, continue with [Basic Transfer](/docs/quick-start/basic-transfer) to send your first payment.",
       "url": "/docs/quick-start/run-a-node/index",
       "source": "docs/quick-start/run-a-node/index.mdx"
     },
     {
+      "id": "chunk-729",
+      "title": "Run a Native Node",
+      "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\n## TL;DR\n\nThe Fiber installer downloads the FNN release bundle and `ckb-cli`, prepares the selected network configuration, guides you through key setup, and creates a reusable startup script.\n\n<Callout type=\"warn\" title=\"Installer release status\">\nThe installer was merged into Fiber's `develop` branch in [PR #1262](https://github.com/nervosnetwork/fiber/pull/1262), after `v0.9.0-rc7` was published. It is not part of a Fiber release yet. The preview below is for Testnet evaluation only; use [manual installation](#manual-installation) for a release-only setup, and do not use the preview with Mainnet funds.\n</Callout>\n\n## Choose an Installation Method",
+      "url": "/docs/quick-start/run-a-node/rust",
+      "source": "docs/quick-start/run-a-node/rust.mdx"
+    },
+    {
       "id": "chunk-730",
       "title": "Run a Native Node",
-      "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\n## TL;DR\n\nDownload the FNN binary, set up a private key, configure `config.yml`, and start the node. In 5 minutes you'll have a Fiber node running on Testnet.\n\n## Prerequisites\n\n- [Git](https://git-scm.com/) (if building from source)\n- [Rust](https://www.rust-lang.org/) and [Cargo](https://doc.rust-lang.org/cargo/) (if building from source)\n- Basic understanding of command line operations\n- [ckb-cli](https://github.com/nervosnetwork/ckb-cli) tool for key management\n\n## Building and Setting Up Your Node\n\n### 1. Obtain the FNN Binary\n\nYou can either download a pre-built binary from the [Fiber GitHub Releases](https://github.com/nervosnetwork/fiber/releases) page or build it from source:",
+      "content": "| Method | Best for | Status |\n|--------|----------|--------|\n| [Automated installer preview](#automated-installer-preview) | Evaluating the simplified setup on Testnet | Merged, not released |\n| [Manual installation](#manual-installation) | Current releases and custom builds | Available now |\n| [Docker](/docs/quick-start/run-a-node/docker) | Reproducible deployments without local binaries | Available now |\n\n## Automated Installer Preview\n\nThe installer supports Linux, macOS, and 64-bit Windows. On Linux and macOS it recognizes `x86_64` and ARM64 release bundles; Windows currently uses the `x86_64` bundle.\n\n### Linux and macOS\n\nRun the bootstrap step. The explicit `develop` ref is required while the installer remains unreleased:",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-731",
       "title": "Run a Native Node",
-      "content": "```sh\ngit clone https://github.com/nervosnetwork/fiber.git\ncd fiber\ncargo build --release\n```\n\nThis document used the [v0.9.0-rc5 binary](https://github.com/nervosnetwork/fiber/releases/tag/v0.9.0-rc5) throughout the guide.\n\n<Callout type=\"info\" title=\"macOS Security\">\nIf you're using macOS, the downloaded binary may be blocked by Gatekeeper. To resolve this, remove the quarantine attribute:\n```sh\nxattr -d com.apple.quarantine fnn fnn-cli\n```\n</Callout>\n\n### 2. Create Node Directory\n\nCreate a dedicated directory for your node and copy the necessary files:",
+      "content": "```bash\ncurl -sSfL https://raw.githubusercontent.com/nervosnetwork/fiber/develop/tools/install/install.sh \\\n  | INSTALL_REF=develop FNN_VERSION=0.9.0-rc7 bash\n```\n\nThis non-interactive step installs the release bundle and `ckb-cli` into `~/.fiber`, writes the Testnet configuration, and saves the guided installer. It does not create or import your CKB key.\n\nRun the guided step to set up the key and startup script:\n\n```bash\n~/.fiber/tools/install/install.sh ~/.fiber testnet\n```\n\nThe guided installer can create a new CKB account or import an existing account. Save the wallet password and the `FIBER_SECRET_KEY_PASSWORD` securely; they protect different operations and may be different values.\n\nWhen setup finishes, accept the prompt to start FNN or start it later with:",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-732",
       "title": "Run a Native Node",
-      "content": "```sh\nmkdir /folder-to/my-fnn\n# If using released binary, replace target/release/fnn with the path to your downloaded binary\ncp target/release/fnn /folder-to/my-fnn\n# Copy additional tools (v0.8.0+)\ncp target/release/fnn-cli /folder-to/my-fnn\ncp config/testnet/config.yml /folder-to/my-fnn\ncd /folder-to/my-fnn\n```\n\n### 3. Set Up Node Keys\n\nFNN includes built-in wallet functionality for signing funding transactions. You'll need to create or import a private key:\n\ncreate a new ckb account and get the `lock_arg` of the new account\n\n```sh\nckb-cli account new",
+      "content": "```bash\ncd ~/.fiber\n./start-node.sh\n```\n\n### Windows PowerShell\n\nThe Windows installer performs the guided setup in one pass. Use Windows PowerShell 5.1 or newer:\n\n```powershell\n$env:INSTALL_REF = \"develop\"\n$env:FNN_VERSION = \"0.9.0-rc7\"\n$env:NETWORK = \"testnet\"\n$env:INSTALL_DIR = \"$HOME\\.fiber\"\nirm https://raw.githubusercontent.com/nervosnetwork/fiber/develop/tools/install/install.ps1 | iex\n```\n\nAfter stopping the node, restart it with:\n\n```powershell\ncd $HOME\\.fiber\n.\\start-node.ps1\n```\n\nYou can also run `start-node.bat` from Command Prompt or double-click it in the install directory.\n\n### What the Installer Creates\n\nThe install directory contains the complete node state and tools:",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-733",
       "title": "Run a Native Node",
-      "content": "# example output\n# address\n#   mainnet: ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqtp83cu4pk8nysm9dngxezw546dyr5w8esx7rlyt\n#   testnet: ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqtp83cu4pk8nysm9dngxezw546dyr5w8esgvgswn\n# lock_arg: 0x613c71ca86c79921b2b6683644ea574d20e8e3e6\n# lock_hash: 0x1c506178212949e961f5949c916f70f5ba0f3b89b14ce2608f02201a41eb3ef7\n```\n\nThen export the existing key\n\n```sh\nmkdir ckb\n# Export an existing key using ckb-cli\nckb-cli account export --lock-arg <lock_arg> --extended-privkey-path ./ckb/exported-key\n# Extract just the private key (FNN only needs this part)\nhead -n 1 ./ckb/exported-key > ./ckb/key\n```\n\n### 4. Start the Node\n\nLaunch your node with logging enabled:",
+      "content": "| Path | Purpose |\n|------|---------|\n| `fnn` / `fnn.exe` | Fiber node binary |\n| `fnn-cli` / `fnn-cli.exe` | CLI for the local RPC endpoint |\n| `config.yml` | Active network configuration |\n| `ckb/key` | CKB private key, encrypted after the first successful start |\n| `fiber/` | Node identity and channel database |\n| `start-node.sh` / `start-node.ps1` | Reusable startup command |\n\n<Callout type=\"warning\" title=\"Keep the password with your backup\">\nEvery restart requires the same `FIBER_SECRET_KEY_PASSWORD` that encrypted `ckb/key`. If either the encrypted key or its password is lost, the key cannot be recovered from that file. Back up the entire install directory and store the password separately in a password manager.\n</Callout>\n\n### Mainnet Requirements",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-734",
       "title": "Run a Native Node",
-      "content": "(You need to set a `FIBER_SECRET_KEY_PASSWORD` environment variable in the startup command to encrypt your wallet private key file. I used 123 here for demo purposes, but I recommend using a strong password.)\n\n```sh\nFIBER_SECRET_KEY_PASSWORD='123' RUST_LOG=info ./fnn -c config.yml -d .\n```\n\n> **Expected Output:** You should see log lines indicating the node is starting, connecting to bootnodes, and syncing with the Testnet. The RPC server will be available at `http://127.0.0.1:8227`.\n\n## Interacting with Your Node\n\nOnce your node is running, you can interact with it using the RPC interface or the CLI tool.\n\n### Using the CLI Tool (v0.8.0+)\n\nv0.8.0 introduces `fnn-cli`, a command-line interface that provides a convenient way to manage your node without writing raw JSON-RPC requests:",
+      "content": "Start on Testnet. A Mainnet installation additionally requires a trusted CKB RPC endpoint. The installer validates that the endpoint is reachable and belongs to the selected network; non-interactive Mainnet setup requires `CKB_RPC_URL` explicitly.\n\nUse a separate install directory for each network. The installer records the selected network and refuses to reuse a directory containing another network's data.\n\n<Callout type=\"warn\">\nWait for a Fiber release that includes PR #1262 before using the installer on Mainnet. After that release, pin production automation to the released installer and FNN version instead of the moving `develop` branch.\n</Callout>\n\n## Manual Installation\n\nUse this path with current Fiber releases or when you need to build FNN yourself.\n\n### Prerequisites",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-735",
       "title": "Run a Native Node",
-      "content": "```sh\n# View node information\n./fnn-cli info\n\n# List connected peers\n./fnn-cli peer list_peers\n\n# List open channels\n./fnn-cli channel list_channels\n\n# List available commands\n./fnn-cli --help\n```\n\n> **Expected Output:** `./fnn-cli info` should return your node's pubkey, alias, and chain info. If you see a connection error, ensure the node is running and `NO_PROXY` is set for local addresses.\n\nThe CLI connects to the node's RPC endpoint (default: `http://127.0.0.1:8227`).\n\n<Callout type=\"info\" title=\"HTTP Proxy Issues\">\nIf you encounter a `503 Service Unavailable` error, check if your system has an HTTP proxy configured. The CLI may attempt to route requests through the proxy, which can fail for local addresses.",
+      "content": "- Basic command-line experience\n- [`ckb-cli`](https://github.com/nervosnetwork/ckb-cli) for key management\n- [Git](https://git-scm.com/), [Rust](https://www.rust-lang.org/), and [Cargo](https://doc.rust-lang.org/cargo/) only when building from source\n\n### 1. Obtain the FNN Binary\n\nDownload a pre-built bundle from [Fiber Releases](https://github.com/nervosnetwork/fiber/releases), or build from source:\n\n```bash\ngit clone https://github.com/nervosnetwork/fiber.git\ncd fiber\ngit checkout v0.9.0-rc7\ncargo build --release\n```\n\nThe examples below use `v0.9.0-rc7`. Keep the binary and configuration from the same release. Omit the checkout step only when you intentionally want to test unreleased source.",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-736",
       "title": "Run a Native Node",
-      "content": "**Solution:** Set `NO_PROXY` to exclude local addresses:\n```sh\nexport NO_PROXY=127.0.0.1,localhost\n./fnn-cli info\n```\n</Callout>\n\n### Using JSON-RPC Directly\n\nYou can also interact with the node using any HTTP client:\n\n```sh\ncurl -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"node_info\"}' \\\n  http://127.0.0.1:8227/\n```\n\n## Version Compatibility and Upgrades\n\nFNN is under active development, and protocol/storage format changes may occur between versions. Here's how to handle upgrades:\n\n<Callout type=\"warn\" title=\"v0.8.0 Breaking Changes\">\nv0.8.0 introduces several RPC changes that may affect existing integrations:",
+      "content": "<Callout type=\"info\" title=\"macOS Security\">\nIf Gatekeeper blocks a downloaded binary, remove its quarantine attribute:\n\n```bash\nxattr -d com.apple.quarantine fnn fnn-cli\n```\n</Callout>\n\n### 2. Create the Node Directory\n\nCreate a dedicated directory and copy the binaries and Testnet configuration into it:\n\n```bash\nmkdir -p /folder-to/my-fnn\ncp target/release/fnn /folder-to/my-fnn\ncp target/release/fnn-cli /folder-to/my-fnn\ncp config/testnet/config.yml /folder-to/my-fnn\ncd /folder-to/my-fnn\n```\n\nWhen using a release bundle, copy its `fnn`, `fnn-cli`, and matching `config/testnet/config.yml` instead of the `target/release` files.\n\n### 3. Create or Import the Node Key\n\nFNN's built-in wallet signs channel funding transactions. Create an account and save its `lock_arg`:",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-737",
       "title": "Run a Native Node",
-      "content": "| Change | v0.7.1 | v0.8.0 |\n|--------|--------|--------|\n| Node identifier | `peer_id` (base58) | `pubkey` (hex-encoded secp256k1) |\n| `node_info` response field | `node_id` | `pubkey` |\n| JSON enum format | PascalCase | snake_case (e.g., `CkbHash` → `ckb_hash`) |\n| `ChannelState` format | Regular | SCREAMING_SNAKE_CASE with pipe separator |\n\nAffected RPC methods: `open_channel`, `list_channels`, `disconnect_peer`, `connect_peer`, `node_info`.\n\nNew RPC methods in v0.8.0:\n- `open_channel_with_external_funding` - For hardware wallet/external signing\n- `submit_signed_funding_tx` - Submit externally signed transactions\n- `list_payments` - Query payment sessions\n</Callout>\n\n### Safe Upgrade Process\n\n1. Close all active channels before upgrading\n2. Stop the node and clean the storage:",
+      "content": "```bash\nckb-cli account new\n```\n\nExport the selected account into the node directory:\n\n```bash\nmkdir -p ckb\nckb-cli account export \\\n  --lock-arg <lock_arg> \\\n  --extended-privkey-path ./ckb/exported-key\nhead -n 1 ./ckb/exported-key > ./ckb/key\nrm ./ckb/exported-key\nchmod 600 ./ckb/key\n```\n\nThe key is plaintext until FNN starts successfully for the first time. Keep the directory private during setup.\n\n### 4. Start the Node\n\nUse a strong, unique password. FNN encrypts a plaintext `ckb/key` on first start and requires the same password on every later start:\n\n```bash\nFIBER_SECRET_KEY_PASSWORD='YOUR_STRONG_PASSWORD' \\\n  RUST_LOG=info \\\n  ./fnn -c config.yml -d .\n```",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-738",
       "title": "Run a Native Node",
-      "content": "```sh\nrm -rf /folder-to/my-fnn/fiber/store\n```\n\n3. Replace the FNN binary and restart\n\n### Storage Migration\n\nStarting from v0.9.0-rc1, storage migration is handled automatically by FNN on startup. When upgrading, simply start FNN normally and it will detect and apply any necessary migrations to preserve your channel state. No separate migration tool is needed.\n\n## Next Steps\n\n- [Basic Transfer](/docs/quick-start/basic-transfer) — send your first payment\n- [Config Reference](/docs/guide/node-operator/config-reference) — full configuration options",
+      "content": "You should see logs for the RPC service, P2P listener, and bootnode connections. The local RPC endpoint is `http://127.0.0.1:8227` by default.\n\n## Interact with Your Node\n\nOpen another terminal in the install directory.\n\n### Use `fnn-cli`\n\n```bash\n# View node information\n./fnn-cli info\n\n# List connected peers\n./fnn-cli peer list_peers\n\n# List open channels\n./fnn-cli channel list_channels\n\n# List available commands\n./fnn-cli --help\n```\n\nThe CLI connects to `http://127.0.0.1:8227` by default.\n\n<Callout type=\"info\" title=\"HTTP proxy issues\">\nIf local CLI calls return `503 Service Unavailable`, exclude loopback addresses from your proxy:\n\n```bash\nexport NO_PROXY=127.0.0.1,localhost\n./fnn-cli info\n```\n</Callout>\n\n### Use JSON-RPC",
       "url": "/docs/quick-start/run-a-node/rust",
       "source": "docs/quick-start/run-a-node/rust.mdx"
     },
     {
       "id": "chunk-739",
+      "title": "Run a Native Node",
+      "content": "```bash\ncurl -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"node_info\"}' \\\n  http://127.0.0.1:8227/\n```\n\n## Stop and Restart\n\nPress `Ctrl+C` in the FNN terminal to stop the node cleanly.\n\nFor an installer-created node, use the generated startup script and enter the original `FIBER_SECRET_KEY_PASSWORD` when prompted:\n\n```bash\ncd ~/.fiber\n./start-node.sh\n```\n\nFor a manual installation, rerun the original `fnn` command with the same data directory, configuration, and password.\n\n## Upgrades and Storage Migration\n\nBack up the entire node directory before every upgrade. Starting with `v0.9.0-rc1`, FNN detects supported database versions and performs required migration during startup.",
+      "url": "/docs/quick-start/run-a-node/rust",
+      "source": "docs/quick-start/run-a-node/rust.mdx"
+    },
+    {
+      "id": "chunk-740",
+      "title": "Run a Native Node",
+      "content": "For databases too old for the current binary, use the migration tool from the appropriate older release first. See [Fiber Node Backup](/docs/operate/backup#cross-version-restore) for the version-specific process.\n\n<Callout type=\"warning\">\nDo not delete `fiber/store` as a routine upgrade step. It contains channel state, and losing channel state can put funds at risk.\n</Callout>\n\n## Next Steps\n\n- [Basic Transfer](/docs/quick-start/basic-transfer) — send your first payment\n- [Connect to Nodes](/docs/operate/connect-nodes) — connect to Fiber peers\n- [Configuration Reference](/docs/operate/config-reference) — review all node settings\n- [Back Up Your Node](/docs/operate/backup) — protect keys, identity, and channel state",
+      "url": "/docs/quick-start/run-a-node/rust",
+      "source": "docs/quick-start/run-a-node/rust.mdx"
+    },
+    {
+      "id": "chunk-741",
       "title": "Transfer Stablecoins",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\nimport { Tabs, Tab } from 'fumadocs-ui/components/tabs';\n\n## TL;DR\n\nSet up three nodes, open UDT (stablecoin) channels, and send a stablecoin payment through a multi-hop path. Builds on the [Basic Transfer](/docs/quick-start/basic-transfer) example.\n\n## Overview\n\nThis guide demonstrates [UDT](https://docs.nervos.org/docs/tech-explanation/glossary#user-defined-token) transfers using stablecoins ([RUSD](https://testnet0815.stablepp.xyz/stablecoin)) across 3 nodes via multi-hop routing.\n\n## Prerequisites\n\n- Completed [Basic Transfer](/docs/quick-start/basic-transfer)\n- [curl](https://curl.se/) for RPC calls\n- [ckb-cli](https://github.com/nervosnetwork/ckb-cli) for key management\n\n## Setting Up Your Environment",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-740",
+      "id": "chunk-742",
       "title": "Transfer Stablecoins",
       "content": "### 1. Prepare Fiber Binary\n\nDownload from [GitHub Releases](https://github.com/nervosnetwork/fiber/releases) or build from source:\n\n```sh\ngit clone https://github.com/nervosnetwork/fiber.git\ncd fiber\ncargo build --release\n```\n\n<Callout type=\"info\" title=\"macOS Security\">\n```sh\nxattr -d com.apple.quarantine fnn fnn-cli\n```\n</Callout>\n\n### 2. Configure Three Nodes\n\n```sh\nfor node in node1 node2 node3; do\n  mkdir $node\n  cp target/release/fnn $node/\n  cp target/release/fnn-cli $node/\n  cp config/testnet/config.yml $node/\ndone\n```\n\nCreate a CKB account for each node and export the keys:\n\n```sh\nckb-cli account new  # repeat 3 times, save each lock_arg",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-741",
+      "id": "chunk-743",
       "title": "Transfer Stablecoins",
       "content": "# For each node directory:\nmkdir ckb\nckb-cli account export --lock-arg <node_lock_arg> --extended-privkey-path ./ckb/exported-key\nhead -n 1 ./ckb/exported-key > ./ckb/key\n```\n\n<Callout type=\"warning\" title=\"Key File Format\">\n`ckb/key` must contain only the 64-character hex private key, no `0x` prefix.\n</Callout>\n\nGet Testnet funds:\n- CKB: [https://faucet.nervos.org](https://faucet.nervos.org/)\n- RUSD: [https://testnet0815.stablepp.xyz/stablecoin](https://testnet0815.stablepp.xyz/stablecoin) (claim via JoyID wallet at [testnet.joyid.dev](https://testnet.joyid.dev/), then transfer to node address)\n\n### 3. Configure Ports\n\n- Node 1: RPC `8227`, P2P `8228`\n- Node 2: RPC `8237`, P2P `8238`\n- Node 3: RPC `8247`, P2P `8248`\n\n<details>\n<summary>View complete config.yml example</summary>",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-742",
+      "id": "chunk-744",
       "title": "Transfer Stablecoins",
       "content": "```yaml\nfiber:\n  listening_addr: \"/ip4/127.0.0.1/tcp/8228\"\n  bootnode_addrs:\n    - \"/ip4/54.179.226.154/tcp/8228/p2p/Qmes1EBD4yNo9Ywkfe6eRw9tG1nVNGLDmMud1xJMsoYFKy\"\n    - \"/ip4/16.163.7.105/tcp/8228/p2p/QmdyQWjPtbK4NWWsvy8s69NGJaQULwgeQDT5ZpNDrTNaeV\"\n  announce_listening_addr: true\n  chain: testnet\n  scripts:\n    - name: FundingLock\n      script:\n        code_hash: 0x6c67887fe201ee0c7853f1682c0b77c0e6214044c156c7558269390a8afa6d7c\n        hash_type: type\n        args: 0x\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0x3cb7c0304fe53f75bb5727e2484d0beae4bd99d979813c6fc97c3cca569f10f6\n        - cell_dep:\n            out_point:\n              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7\n              index: 0x0\n            dep_type: code\n    - name: CommitmentLock\n      script:\n        code_hash: 0x740dee83f87c6f309824d8fd3fbdd3c8380ee6fc9acc90b1a748438afcdf81d8\n        hash_type: type\n        args: 0x\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0xf7e458887495cf70dd30d1543cad47dc1dfe9d874177bf19291e4db478d5751b\n        - cell_dep:\n            out_point:\n              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7\n              index: 0x0\n            dep_type: code\nrpc:\n  listening_addr: \"127.0.0.1:8227\"\nckb:\n  rpc_url: \"https://testnet.ckbapp.dev/\"\n  udt_whitelist:\n    - name: RUSD\n      script:\n        code_hash: 0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\n        hash_type: type\n        args: 0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\n      cell_deps:\n        - type_id:\n            code_hash: 0x00000000000000000000000000000000000000000000000000545950455f4944\n            hash_type: type\n            args: 0x97d30b723c0b2c66e9cb8d4d0df4ab5d7222cbb00d4a9a2055ce2e5d7f0d8b0f\n      auto_accept_amount: 10\nservices:\n  - fiber\n  - rpc\n  - ckb\n```\n</details>",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-743",
+      "id": "chunk-745",
       "title": "Transfer Stablecoins",
       "content": "### 4. Start All Nodes\n\n```sh\n# Terminal 1\ncd node1 && FIBER_SECRET_KEY_PASSWORD='password1' RUST_LOG=info ./fnn -c config.yml -d .\n\n# Terminal 2\ncd node2 && FIBER_SECRET_KEY_PASSWORD='password2' RUST_LOG=info ./fnn -c config.yml -d .\n\n# Terminal 3\ncd node3 && FIBER_SECRET_KEY_PASSWORD='password3' RUST_LOG=info ./fnn -c config.yml -d .\n```\n\n## Creating Stablecoin Payment Channels\n\n### 1. Connect Node 1 and Node 2",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-744",
+      "id": "chunk-746",
       "title": "Transfer Stablecoins",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli peer connect_peer --address \"/ip4/127.0.0.1/tcp/8238/p2p/<node2_peer_id>\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl --location 'http://127.0.0.1:8227' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"connect_peer\",\n    \"params\": [{\"pubkey\": \"<node2_pubkey>\", \"address\": \"/ip4/127.0.0.1/tcp/8238\"}]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nawait sdk.connectPeer({\n  address: \"/ip4/127.0.0.1/tcp/8238/p2p/<node2_peer_id>\",\n});\n```\n  </Tab>\n</Tabs>\n\nGet Node 2's peer ID and pubkey: `cd node2 && ./fnn-cli --url http://127.0.0.1:8237 info`\n\n### 2. Open a Stablecoin Channel (Node 1 → Node 2)\n\nThe `funding_udt_type_script` identifies the RUSD token:",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-745",
+      "id": "chunk-747",
       "title": "Transfer Stablecoins",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli channel open_channel \\\n  --pubkey <node2_pubkey> \\\n  --funding-amount 10 \\\n  --public true \\\n  --funding-udt-type-script '{\"code_hash\":\"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\"hash_type\":\"type\",\"args\":\"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"}'\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl --location 'http://127.0.0.1:8227' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"open_channel\",\n    \"params\": [{\n      \"pubkey\": \"<node2_pubkey>\",\n      \"funding_amount\": \"0xa\",\n      \"public\": true,\n      \"funding_udt_type_script\": {\n        \"code_hash\": \"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\n        \"hash_type\": \"type\",\n        \"args\": \"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"\n      }\n    }]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// funding_amount: 0xa = 10 RUSD\nconst tempChannelId = await sdk.openChannel({\n  pubkey: \"<node2_pubkey>\",\n  fundingAmount: \"0xa\",\n  public: true,\n  fundingUdtTypeScript: {\n    codeHash: \"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\n    hashType: \"type\",\n    args: \"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\",\n  },\n});\nconsole.log(\"Temporary channel ID:\", tempChannelId);\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-746",
+      "id": "chunk-748",
       "title": "Transfer Stablecoins",
       "content": "<Callout type=\"warning\" title=\"CKB Requirement\">\nOpening a UDT channel also requires ~99 CKB in the node's wallet to cover on-chain cell capacity and shutdown fees. Make sure each node has sufficient CKB balance from the faucet.\n</Callout>\n\n### 3. Monitor Channel Status\n\nWait until `state.state_name` becomes `\"ChannelReady\"`:",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-747",
+      "id": "chunk-749",
       "title": "Transfer Stablecoins",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n./fnn-cli channel list_channels\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl --location 'http://127.0.0.1:8227' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{}]}'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst channels = await sdk.listChannels();\nfor (const ch of channels) {\n  console.log(`${ch.channelId} — ${ch.state.stateName}`);\n}\n```\n  </Tab>\n</Tabs>\n\nRepeat steps 1–3 to connect Node 2 and Node 3 (using ports `8247`/`8248`).\n\n## Generating Invoices and Making Payments\n\n### 1. Generate a Stablecoin Invoice on Node 2",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-748",
+      "id": "chunk-750",
       "title": "Transfer Stablecoins",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node2 && ./fnn-cli --url http://127.0.0.1:8237 invoice new_invoice \\\n  --amount 10 \\\n  --currency Fibt \\\n  --description \"test stablecoin invoice\" \\\n  --expiry 3600 \\\n  --udt-type-script '{\"code_hash\":\"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\"hash_type\":\"type\",\"args\":\"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"}'\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl --location 'http://127.0.0.1:8237' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"new_invoice\",\n    \"params\": [{\n      \"amount\": \"0xa\",\n      \"currency\": \"Fibt\",\n      \"description\": \"test stablecoin invoice\",\n      \"expiry\": \"0xe10\",\n      \"udt_type_script\": {\n        \"code_hash\": \"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\n        \"hash_type\": \"type\",\n        \"args\": \"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"\n      }\n    }]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// Create invoice on Node 2\nconst node2 = new FiberSDK({ endpoint: \"http://127.0.0.1:8237\" });\nconst { invoiceAddress } = await node2.newInvoice({\n  amount: \"0xa\",\n  currency: \"Fibt\",\n  description: \"test stablecoin invoice\",\n  expiry: \"0xe10\",\n  udtTypeScript: {\n    codeHash: \"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\n    hashType: \"type\",\n    args: \"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\",\n  },\n});\nconsole.log(\"Invoice:\", invoiceAddress);\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-749",
+      "id": "chunk-751",
       "title": "Transfer Stablecoins",
       "content": "<Callout type=\"info\">\nThe `payment_preimage` is auto-generated by both CLI and RPC. You can optionally provide your own with `\"payment_preimage\": \"<your_preimage>\"` in the RPC params if needed.\n</Callout>\n\n### 2. Send the Stablecoin Payment from Node 1",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-750",
+      "id": "chunk-752",
       "title": "Transfer Stablecoins",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli payment send_payment --invoice \"fibt10000000001p...\"\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl --location 'http://127.0.0.1:8227' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"send_payment\",\n    \"params\": [{\"invoice\": \"fibt10000000001p...\"}]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nconst result = await sdk.sendPayment({ invoice: \"fibt10000000001p...\" });\nconsole.log(\"Payment hash:\", result.paymentHash);\nconsole.log(\"Status:\", result.status);\n```\n  </Tab>\n</Tabs>\n\n### 3. Check Channel Balance\n\n<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\n# Node 1\n./fnn-cli channel list_channels",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-751",
+      "id": "chunk-753",
       "title": "Transfer Stablecoins",
       "content": "# Node 2\n./fnn-cli --url http://127.0.0.1:8237 channel list_channels\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl --location 'http://127.0.0.1:8227' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{}]}'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\n// Node 1\nconst node1Channels = await sdk.listChannels();\nfor (const ch of node1Channels) {\n  console.log(`local: ${ch.localBalance}, remote: ${ch.remoteBalance}`);\n}\n\n// Node 2\nconst node2Channels = await node2.listChannels();\nfor (const ch of node2Channels) {\n  console.log(`local: ${ch.localBalance}, remote: ${ch.remoteBalance}`);\n}\n```\n  </Tab>\n</Tabs>\n\n## Closing the Channel",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-752",
+      "id": "chunk-754",
       "title": "Transfer Stablecoins",
       "content": "<Tabs items={['CLI', 'RPC', 'CCC']}>\n  <Tab value=\"CLI\">\n```sh\ncd node1 && ./fnn-cli channel shutdown_channel \\\n  --channel-id <channel_id> \\\n  --close-script '{\"code_hash\":\"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\"hash_type\":\"type\",\"args\":\"<your_lock_arg>\"}' \\\n  --fee-rate 1000\n```\n  </Tab>\n  <Tab value=\"RPC\">\n```sh\ncurl --location 'http://127.0.0.1:8227' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"shutdown_channel\",\n    \"params\": [{\n      \"channel_id\": \"<channel_id>\",\n      \"close_script\": {\n        \"code_hash\": \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n        \"hash_type\": \"type\",\n        \"args\": \"<your_lock_arg>\"\n      },\n      \"fee_rate\": \"0x3e8\"\n    }]\n  }'\n```\n  </Tab>\n  <Tab value=\"CCC\">\n```typescript\nawait sdk.shutdownChannel({\n  channelId: \"<channel_id>\",\n  closeScript: {\n    codeHash: \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n    hashType: \"type\",\n    args: \"<your_lock_arg>\",\n  },\n  feeRate: \"0x3e8\",\n});\nconsole.log(\"Channel closed.\");\n```\n  </Tab>\n</Tabs>",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-753",
+      "id": "chunk-755",
       "title": "Transfer Stablecoins",
       "content": "<Callout type=\"info\" title=\"close_script\">\nGet `args` from `fnn-cli info` under `default_funding_lock_script.args`. The `fee_rate` (shannons/KW) is optional and defaults to `1000`. You can also use `--force` (CLI) or `\"force\": true` (RPC) to force-close a channel unilaterally, in which case `close_script` and `fee_rate` are ignored.\n</Callout>\n\n## Important Notes",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-754",
+      "id": "chunk-756",
       "title": "Transfer Stablecoins",
       "content": "- **RUSD amounts**: CLI uses base units (e.g. `10` = 10 RUSD); RPC uses hex strings (e.g. `\"0xa\"` = 10)\n- **Invoice currency**: Use `\"Fibt\"` for testnet, not `\"RUSD\"`\n- **auto_accept_amount**: Channels with funding below this value require manual acceptance\n- **Channel state format**: The `list_channels` response returns state as a nested object: `state.state_name` (e.g. `\"ChannelReady\"`) and `state.state_flags` (e.g. `[\"PublicChannel\"]`)\n- **Gossip sync time**: After starting nodes, wait for the gossip protocol to fully sync the network graph before attempting multi-hop payments. This may take several minutes depending on network conditions.",
       "url": "/docs/quick-start/transfer-stablecoin",
       "source": "docs/quick-start/transfer-stablecoin.mdx"
     },
     {
-      "id": "chunk-755",
+      "id": "chunk-757",
       "title": "Fiber Cheat Code",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\nA quick-reference cheat sheet for Fiber developers and node operators. Keep this page bookmarked for everyday operations.\n\n## Node Quick Start\n\nUse [Run a Fiber Node](/docs/quick-start/run-a-node) for installation and startup steps. This page focuses on command, RPC, and configuration quick references after a node is running.\n\n<Callout type=\"info\">\n  The default RPC endpoint is `http://127.0.0.1:8227`. Use `--url` with `fnn-cli` to target a different node (e.g. `./fnn-cli --url http://127.0.0.1:8237 info`).\n</Callout>\n\n<Callout type=\"info\" title=\"HTTP Proxy Issues\">\n  If you encounter 503 errors with `fnn-cli`, run:\n  ```bash\n  export NO_PROXY=127.0.0.1,localhost\n  ```\n</Callout>",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
-      "id": "chunk-756",
+      "id": "chunk-758",
       "title": "Fiber Cheat Code",
       "content": "<Callout type=\"info\" title=\"Caller Perspective\">\n  Fiber RPC and CLI commands act on the node you target. In a two-node payment flow, create invoices on the receiver/payee node and send payments from the sender/payer node. Channel balances and configuration are also returned or updated from the local node's perspective.\n</Callout>\n\n## Common CLI Commands\n\n### Node & Peer",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
-      "id": "chunk-757",
+      "id": "chunk-759",
       "title": "Fiber Cheat Code",
       "content": "| Category | Operation | Run on | Command |\n|----------|-----------|--------|---------|\n| Node | List available commands | Any shell | `fnn-cli --help` |\n| Node | View node info | Node being inspected | `fnn-cli info` |\n| Peer | Connect to a peer (by pubkey) | Node initiating the connection | `fnn-cli peer connect_peer --pubkey <pubkey>` |\n| Peer | Connect to a WSS peer (by pubkey) | Browser/WASM-facing or WSS-capable node | `fnn-cli peer connect_peer --pubkey <pubkey> --addr-type wss` |\n| Peer | Connect to a peer (by address) | Node initiating the connection | `fnn-cli peer connect_peer --address \"/ip4/<ip>/tcp/<port>\"` |\n| Peer | List connected peers | Node being inspected | `fnn-cli peer list_peers` |\n| Peer | Disconnect a peer | Node dropping the connection | `fnn-cli peer disconnect_peer --pubkey <pubkey>` |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
-      "id": "chunk-758",
+      "id": "chunk-760",
       "title": "Fiber Cheat Code",
       "content": "### Channel",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
-      "id": "chunk-759",
+      "id": "chunk-761",
       "title": "Fiber Cheat Code",
       "content": "| Category | Operation | Run on | Command |\n|----------|-----------|--------|---------|\n| Channel | Open a CKB channel | Channel initiator / funder | `fnn-cli channel open_channel --pubkey <pubkey> --funding-amount <shannons>` |\n| Channel | Open a UDT channel | Channel initiator / funder | `fnn-cli channel open_channel --pubkey <pubkey> --funding-amount <base_units> --funding-udt-type-script '<json>'` |\n| Channel | List all channels | Node whose local channel state you want | `fnn-cli channel list_channels` |\n| Channel | List pending opens only | Node whose local pending channel state you want | `fnn-cli channel list_channels --only-pending true` |\n| Channel | Close a channel | Either channel participant; caller initiates close | `fnn-cli channel shutdown_channel --channel-id <id> --force true` |\n| Channel | Update channel config | Node whose local forwarding config you want to change | `fnn-cli channel update_channel --channel-id <id> --tlc-minimum-value <base_units>` |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
-      "id": "chunk-760",
-      "title": "Fiber Cheat Code",
-      "content": "### Invoice & Payment",
-      "url": "/docs/res/cheat-code",
-      "source": "docs/res/cheat-code.mdx"
-    },
-    {
-      "id": "chunk-761",
-      "title": "Fiber Cheat Code",
-      "content": "| Category | Operation | Run on | Command |\n|----------|-----------|--------|---------|\n| Invoice | Create a CKB invoice | Receiver / payee | `fnn-cli invoice new_invoice --amount 10000000000 --currency Fibt --description \"Test\"` |\n| Invoice | Create a UDT invoice | Receiver / payee | `fnn-cli invoice new_invoice --amount <base_units> --currency Fibt --udt-type-script '<json>'` |\n| Invoice | Parse an invoice | Any node or shell targeting a node | `fnn-cli invoice parse_invoice --invoice \"fibt1...\"` |\n| Payment | Send payment | Sender / payer; not the node that created the invoice | `fnn-cli payment send_payment --invoice \"fibt1...\"` |\n| Payment | Send keysend payment | Sender / payer | `fnn-cli payment send_payment --target-pubkey <pubkey> --amount <shannons> --keysend true` |\n| Payment | Check payment status | Sender / payer that created the payment session | `fnn-cli payment get_payment --payment-hash 0x...` |\n| Payment | List all payments | Sender / payer whose payment sessions you want | `fnn-cli payment list_payments` |",
-      "url": "/docs/res/cheat-code",
-      "source": "docs/res/cheat-code.mdx"
-    },
-    {
       "id": "chunk-762",
       "title": "Fiber Cheat Code",
-      "content": "<Callout type=\"warning\">\n  **Amount encoding differs between CLI and RPC**: `fnn-cli` accepts decimal integers in the underlying unit, while RPC JSON uses hex strings for integer fields. For CKB, the underlying unit is shannons (`100000000` = 1 CKB). For UDTs, use the token's base units. `fnn-cli` does not treat `1000` as 1000 CKB.\n</Callout>\n\n## RPC Quick Reference\n\nThe default RPC endpoint is `http://127.0.0.1:8227`. All calls use JSON-RPC 2.0.\n\n### Node & Peer",
+      "content": "### Invoice & Payment",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-763",
       "title": "Fiber Cheat Code",
-      "content": "| Method | Run on | Description | Key Params |\n|--------|--------|-------------|------------|\n| `node_info` | Node being inspected | Get node identity & config | — |\n| `connect_peer` | Node initiating the connection | Connect to a remote peer | `pubkey`, `address`, `save`, `addr_type` |\n| `disconnect_peer` | Node dropping the connection | Disconnect from a peer | `pubkey` |\n| `list_peers` | Node being inspected | List connected peers | — |\n\n### Channel",
+      "content": "| Category | Operation | Run on | Command |\n|----------|-----------|--------|---------|\n| Invoice | Create a CKB invoice | Receiver / payee | `fnn-cli invoice new_invoice --amount 10000000000 --currency Fibt --description \"Test\"` |\n| Invoice | Create a UDT invoice | Receiver / payee | `fnn-cli invoice new_invoice --amount <base_units> --currency Fibt --udt-type-script '<json>'` |\n| Invoice | Parse an invoice | Any node or shell targeting a node | `fnn-cli invoice parse_invoice --invoice \"fibt1...\"` |\n| Payment | Send payment | Sender / payer; not the node that created the invoice | `fnn-cli payment send_payment --invoice \"fibt1...\"` |\n| Payment | Send keysend payment | Sender / payer | `fnn-cli payment send_payment --target-pubkey <pubkey> --amount <shannons> --keysend true` |\n| Payment | Check payment status | Sender / payer that created the payment session | `fnn-cli payment get_payment --payment-hash 0x...` |\n| Payment | List all payments | Sender / payer whose payment sessions you want | `fnn-cli payment list_payments` |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-764",
       "title": "Fiber Cheat Code",
-      "content": "| Method | Run on | Description | Key Params |\n|--------|--------|-------------|------------|\n| `open_channel` | Channel initiator / funder | Open a new channel | `pubkey`, `funding_amount`, `public`, `one_way`, `funding_fee_rate`, `funding_udt_type_script` |\n| `open_channel_with_external_funding` | Initiator whose external wallet controls `funding_lock_script` | Negotiate a channel funded by an external wallet | `pubkey`, `funding_amount`, `shutdown_script`, `funding_lock_script`, `funding_lock_script_cell_deps` |\n| `submit_signed_funding_tx` | Same node that called `open_channel_with_external_funding` | Submit the externally signed funding transaction | `channel_id`, `signed_funding_tx` |\n| `accept_channel` | Acceptor / node that received the pending open request | Manually accept a pending channel | `temporary_channel_id`, `funding_amount` |\n| `list_channels` | Node whose local channel state you want | List channels; balances are local perspective | `pubkey`, `include_closed`, `only_pending` |\n| `shutdown_channel` | Either channel participant; caller initiates close | Close a channel | `channel_id`, `close_script`, `fee_rate`, `force` |\n| `update_channel` | Node whose local forwarding config you want to change | Update channel parameters | `channel_id`, `tlc_fee_proportional_millionths`, `tlc_minimum_value`, `tlc_expiry_delta` |",
+      "content": "<Callout type=\"warning\">\n  **Amount encoding differs between CLI and RPC**: `fnn-cli` accepts decimal integers in the underlying unit, while RPC JSON uses hex strings for integer fields. For CKB, the underlying unit is shannons (`100000000` = 1 CKB). For UDTs, use the token's base units. `fnn-cli` does not treat `1000` as 1000 CKB.\n</Callout>\n\n## RPC Quick Reference\n\nThe default RPC endpoint is `http://127.0.0.1:8227`. All calls use JSON-RPC 2.0.\n\n### Node & Peer",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-765",
       "title": "Fiber Cheat Code",
-      "content": "### Invoice & Payment",
+      "content": "| Method | Run on | Description | Key Params |\n|--------|--------|-------------|------------|\n| `node_info` | Node being inspected | Get node identity & config | — |\n| `connect_peer` | Node initiating the connection | Connect to a remote peer | `pubkey`, `address`, `save`, `addr_type` |\n| `disconnect_peer` | Node dropping the connection | Disconnect from a peer | `pubkey` |\n| `list_peers` | Node being inspected | List connected peers | — |\n\n### Channel",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-766",
       "title": "Fiber Cheat Code",
-      "content": "| Method | Run on | Description | Key Params |\n|--------|--------|-------------|------------|\n| `new_invoice` | Receiver / payee | Create an invoice and store its preimage locally | `amount`, `currency`, `description`, `expiry`, `udt_type_script` |\n| `parse_invoice` | Any node | Decode an invoice string | `invoice` |\n| `send_payment` | Sender / payer; not the node that created the invoice | Send a payment | `invoice` or `target_pubkey` + `amount` + `keysend` |\n| `build_router` | Sender / payer route source | Build an explicit route | `hops_info`, `amount`, `udt_type_script` |\n| `send_payment_with_router` | Sender / payer route source | Send with a manually supplied route | `router`, `invoice` or `keysend` |\n| `get_payment` | Sender / payer that created the payment session | Get payment status | `payment_hash` |\n| `list_payments` | Sender / payer whose payment sessions you want | List payments | `status`, `limit`, `after` |",
+      "content": "| Method | Run on | Description | Key Params |\n|--------|--------|-------------|------------|\n| `open_channel` | Channel initiator / funder | Open a new channel | `pubkey`, `funding_amount`, `public`, `one_way`, `funding_fee_rate`, `funding_udt_type_script` |\n| `open_channel_with_external_funding` | Initiator whose external wallet controls `funding_lock_script` | Negotiate a channel funded by an external wallet | `pubkey`, `funding_amount`, `shutdown_script`, `funding_lock_script`, `funding_lock_script_cell_deps` |\n| `submit_signed_funding_tx` | Same node that called `open_channel_with_external_funding` | Submit the externally signed funding transaction | `channel_id`, `signed_funding_tx` |\n| `accept_channel` | Acceptor / node that received the pending open request | Manually accept a pending channel | `temporary_channel_id`, `funding_amount` |\n| `list_channels` | Node whose local channel state you want | List channels; balances are local perspective | `pubkey`, `include_closed`, `only_pending` |\n| `shutdown_channel` | Either channel participant; caller initiates close | Close a channel | `channel_id`, `close_script`, `fee_rate`, `force` |\n| `update_channel` | Node whose local forwarding config you want to change | Update channel parameters | `channel_id`, `tlc_fee_proportional_millionths`, `tlc_minimum_value`, `tlc_expiry_delta` |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-767",
       "title": "Fiber Cheat Code",
-      "content": "### Example RPC Call\n\n```bash\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"node_info\", \"params\": []}' \\\n  http://127.0.0.1:8227\n```\n\n## Channel Lifecycle\n\n```\nNegotiatingFunding -> CollaboratingFundingTx -> SigningCommitment\nSigningCommitment -> AwaitingTxSignatures -> AwaitingChannelReady\nAwaitingChannelReady -> ChannelReady -> ShuttingDown -> Closed\n```",
+      "content": "### Invoice & Payment",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-768",
       "title": "Fiber Cheat Code",
-      "content": "| State | Description |\n|-------|-------------|\n| **NegotiatingFunding** | Peers are negotiating channel parameters; external funding may be waiting for user-signed tx submission |\n| **CollaboratingFundingTx** | Peers are collaborating on the funding transaction |\n| **SigningCommitment** | Funding collaboration is complete; peers are exchanging commitment signatures |\n| **AwaitingTxSignatures** | Commitment signatures are exchanged; peers are finalizing funding transaction signatures |\n| **AwaitingChannelReady** | Funding transaction is submitted/confirmed and peers are exchanging channel-ready messages |\n| **ChannelReady** | Channel is open and operational; off-chain payments are possible |\n| **ShuttingDown** | A cooperative shutdown has started |\n| **Closed** | Channel is fully settled on-chain |",
+      "content": "| Method | Run on | Description | Key Params |\n|--------|--------|-------------|------------|\n| `new_invoice` | Receiver / payee | Create an invoice and store its preimage locally | `amount`, `currency`, `description`, `expiry`, `udt_type_script` |\n| `parse_invoice` | Any node | Decode an invoice string | `invoice` |\n| `send_payment` | Sender / payer; not the node that created the invoice | Send a payment | `invoice` or `target_pubkey` + `amount` + `keysend` |\n| `build_router` | Sender / payer route source | Build an explicit route | `hops_info`, `amount`, `udt_type_script` |\n| `send_payment_with_router` | Sender / payer route source | Send with a manually supplied route | `router`, `invoice` or `keysend` |\n| `get_payment` | Sender / payer that created the payment session | Get payment status | `payment_hash` |\n| `list_payments` | Sender / payer whose payment sessions you want | List payments | `status`, `limit`, `after` |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-769",
       "title": "Fiber Cheat Code",
-      "content": "<Callout type=\"info\">\n  Use `fnn-cli channel list_channels` to check the state of your channels. JSON-RPC returns states as `{\"state_name\":\"ChannelReady\"}` and similar PascalCase names. Each side must reserve **99 CKB** (98 for commitment lock + 1 for shutdown fee).\n</Callout>\n\n## Payment Lifecycle\n\n```\nCreated ──▶ Inflight ──┬──▶ Success\n                       └──▶ Failed\n```\n\n| State | Description |\n|-------|-------------|\n| **Created** | Payment session initialized; no TLC has been dispatched yet |\n| **Inflight** | At least one payment attempt is active or waiting for settlement/retry |\n| **Success** | Payment settled; preimage revealed, funds transferred |\n| **Failed** | Payment terminated after failures or exhausted retries |",
+      "content": "### Example RPC Call\n\n```bash\ncurl -s -X POST -H \"Content-Type: application/json\" \\\n  -d '{\"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"node_info\", \"params\": []}' \\\n  http://127.0.0.1:8227\n```\n\n## Channel Lifecycle\n\n```\nNegotiatingFunding -> CollaboratingFundingTx -> SigningCommitment\nSigningCommitment -> AwaitingTxSignatures -> AwaitingChannelReady\nAwaitingChannelReady -> ChannelReady -> ShuttingDown -> Closed\n```",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-770",
       "title": "Fiber Cheat Code",
-      "content": "Fiber uses a **two-level state machine**: a high-level `PaymentSession` represents the intent, and one or more `PaymentAttempt`s handle actual routing. An attempt can move through `Created`, `Inflight`, `Retrying`, `Success`, and `Failed`.\n\n## Fee Calculation\n\nThe forwarding fee for a TLC (Timelock Contract) is calculated as:\n\n```\nfee = ⌈(amount × tlc_fee_proportional_millionths) / 1,000,000⌉\n```\n\n**Example**: With `tlc_fee_proportional_millionths = 1000` (0.1%), forwarding 1,000 CKB earns the relay node 1 CKB.\n\n<Callout type=\"info\">\n  The fee is calculated using the **outbound** channel's configuration. For a path A → B → C, the fee B charges is based on the channel between B and C, not A and B.\n</Callout>\n\n## Important Constants & Parameters",
+      "content": "| State | Description |\n|-------|-------------|\n| **NegotiatingFunding** | Peers are negotiating channel parameters; external funding may be waiting for user-signed tx submission |\n| **CollaboratingFundingTx** | Peers are collaborating on the funding transaction |\n| **SigningCommitment** | Funding collaboration is complete; peers are exchanging commitment signatures |\n| **AwaitingTxSignatures** | Commitment signatures are exchanged; peers are finalizing funding transaction signatures |\n| **AwaitingChannelReady** | Funding transaction is submitted/confirmed and peers are exchanging channel-ready messages |\n| **ChannelReady** | Channel is open and operational; off-chain payments are possible |\n| **ShuttingDown** | A cooperative shutdown has started |\n| **Closed** | Channel is fully settled on-chain |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-771",
       "title": "Fiber Cheat Code",
-      "content": "| Parameter | Purpose | Default / Typical Value |\n|-----------|---------|------------------------|\n| **Reserved CKB** | Channel reserve for lock and fees | 99 CKB (98 commitment + 1 shutdown fee) |\n| `tlc_fee_proportional_millionths` | Forwarding fee rate | 1000 (= 0.1%) |\n| `tlc_min_value` | Minimum TLC value to forward | 0 (any amount) |\n| `tlc_expiry_delta` | TLC expiry window (milliseconds) | 14400000 (4 hours) |\n| `commitment_delay_epoch` | Commitment delay / to-self delay | 1 epoch (~4 hours) |\n| `max_tlc_value_in_flight` | Max total TLC value in flight | `u128::MAX` by default; set at channel open, not updatable |\n| `max_tlc_number_in_flight` | Max number of TLCs in flight | 125 |\n| `pending_channels_number_limit` | Global max pending channel openings | 100 |\n| `to_be_accepted_channels_number_limit` | Max pending channel openings from one peer | 20 |\n| `open_channel_auto_accept_min_ckb_funding_amount` | Min CKB funding for auto-accept | Built-in default: 10000000000 (100 CKB); public nodes commonly require 499 CKB funding |\n| `auto_accept_channel_ckb_funding_amount` | Auto-accept contribution | Built-in default: 9900000000 (99 CKB); public nodes commonly contribute 25000000000 (250 CKB) |",
+      "content": "<Callout type=\"info\">\n  Use `fnn-cli channel list_channels` to check the state of your channels. JSON-RPC returns states as `{\"state_name\":\"ChannelReady\"}` and similar PascalCase names. Each side must reserve **99 CKB** (98 for commitment lock + 1 for shutdown fee).\n</Callout>\n\n## Payment Lifecycle\n\n```\nCreated ──▶ Inflight ──┬──▶ Success\n                       └──▶ Failed\n```\n\n| State | Description |\n|-------|-------------|\n| **Created** | Payment session initialized; no TLC has been dispatched yet |\n| **Inflight** | At least one payment attempt is active or waiting for settlement/retry |\n| **Success** | Payment settled; preimage revealed, funds transferred |\n| **Failed** | Payment terminated after failures or exhausted retries |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-772",
       "title": "Fiber Cheat Code",
-      "content": "## Capacity Formula\n\nFor CKB channels, each side must reserve CKB for on-chain operations:\n\n```\nAvailable Balance = Funded Amount − 99 CKB\n```\n\n**Example**: Fund 499 CKB → 499 − 99 = **400 CKB** available for off-chain payments.\n\n<Callout type=\"warning\">\n  The 99 CKB reserve is **per side**. In a two-party CKB channel, both sides must reserve this amount. This reserve is not available for CKB payments — it covers the commitment transaction lock and the shutdown transaction fee. For UDT channels, the channel balance is in token base units, but the funding transaction still needs enough CKB capacity and fees.\n</Callout>\n\n## Testnet Resources",
+      "content": "Fiber uses a **two-level state machine**: a high-level `PaymentSession` represents the intent, and one or more `PaymentAttempt`s handle actual routing. An attempt can move through `Created`, `Inflight`, `Retrying`, `Success`, and `Failed`.\n\n## Fee Calculation\n\nThe forwarding fee for a TLC (Timelock Contract) is calculated as:\n\n```\nfee = ⌈(amount × tlc_fee_proportional_millionths) / 1,000,000⌉\n```\n\n**Example**: With `tlc_fee_proportional_millionths = 1000` (0.1%), forwarding 1,000 CKB earns the relay node 1 CKB.\n\n<Callout type=\"info\">\n  The fee is calculated using the **outbound** channel's configuration. For a path A → B → C, the fee B charges is based on the channel between B and C, not A and B.\n</Callout>\n\n## Important Constants & Parameters",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-773",
       "title": "Fiber Cheat Code",
-      "content": "| Resource | URL | Notes |\n|----------|-----|-------|\n| CKB Testnet Faucet | [faucet.nervos.org](https://faucet.nervos.org) | Get testnet CKB |\n| RUSD Stablecoin | [testnet0815.stablepp.xyz](https://testnet0815.stablepp.xyz/stablecoin) | Mint testnet RUSD |\n| CKB Explorer | [explorer.nervos.org](https://explorer.nervos.org/aggron) | Testnet block explorer |\n| Fiber Dashboard | [dashboard.fiber.channel](https://dashboard.fiber.channel/nodes) | Network topology & stats |\n| Fiber Releases | [GitHub Releases](https://github.com/nervosnetwork/fiber/releases) | Download latest binary |\n\n### Public Testnet Nodes",
+      "content": "| Parameter | Purpose | Default / Typical Value |\n|-----------|---------|------------------------|\n| **Reserved CKB** | Channel reserve for lock and fees | 99 CKB (98 commitment + 1 shutdown fee) |\n| `tlc_fee_proportional_millionths` | Forwarding fee rate | 1000 (= 0.1%) |\n| `tlc_min_value` | Minimum TLC value to forward | 0 (any amount) |\n| `tlc_expiry_delta` | TLC expiry window (milliseconds) | 14400000 (4 hours) |\n| `commitment_delay_epoch` | Commitment delay / to-self delay | 1 epoch (~4 hours) |\n| `max_tlc_value_in_flight` | Max total TLC value in flight | `u128::MAX` by default; set at channel open, not updatable |\n| `max_tlc_number_in_flight` | Max number of TLCs in flight | 125 |\n| `pending_channels_number_limit` | Global max pending channel openings | 100 |\n| `to_be_accepted_channels_number_limit` | Max pending channel openings from one peer | 20 |\n| `open_channel_auto_accept_min_ckb_funding_amount` | Min CKB funding for auto-accept | Built-in default: 10000000000 (100 CKB); public nodes commonly require 499 CKB funding |\n| `auto_accept_channel_ckb_funding_amount` | Auto-accept contribution | Built-in default: 9900000000 (99 CKB); public nodes commonly contribute 25000000000 (250 CKB) |",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-774",
       "title": "Fiber Cheat Code",
-      "content": "| Name | Pubkey | Auto-accept CKB | Auto-accept UDT |\n|------|--------|------------------|------------------|\n| fiber-testnet-public-bottle | `02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71` | ≥ 499 CKB | RUSD ≥ 20 |\n| fiber-testnet-public-bracer | `0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc` | ≥ 499 CKB | RUSD ≥ 20 |\n\n## Common Patterns\n\n### Multi-Hop Routing\n\nYou don't need a direct channel to every peer. Fiber automatically discovers paths through intermediate relay nodes:",
+      "content": "## Capacity Formula\n\nFor CKB channels, each side must reserve CKB for on-chain operations:\n\n```\nAvailable Balance = Funded Amount − 99 CKB\n```\n\n**Example**: Fund 499 CKB → 499 − 99 = **400 CKB** available for off-chain payments.\n\n<Callout type=\"warning\">\n  The 99 CKB reserve is **per side**. In a two-party CKB channel, both sides must reserve this amount. This reserve is not available for CKB payments — it covers the commitment transaction lock and the shutdown transaction fee. For UDT channels, the channel balance is in token base units, but the funding transaction still needs enough CKB capacity and fees.\n</Callout>\n\n## Testnet Resources",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-775",
       "title": "Fiber Cheat Code",
-      "content": "```\n┌───────┐        ┌───────┐        ┌───────┐        ┌───────┐\n│ nodeA │ ─────▶ │ node1 │ ─────▶ │ node2 │ ─────▶ │ nodeB │\n│:8227  │        │public │        │public │        │:8237  │\n└───────┘        └───────┘        └───────┘        └───────┘\n  sender        relay node 1     relay node 2      receiver\n```\n\nLocal nodes do not need a public IP — they connect through public relay nodes. See [Multi-Hop Routing](/docs/concept/routing/multi-hop) for full details.\n\n### Channel Rebalancing\n\nWhen one side of a channel is depleted, rebalance by sending a payment back to yourself:\n\n**Automatic** — use `send_payment` with `allow_self_payment: true`:",
+      "content": "| Resource | URL | Notes |\n|----------|-----|-------|\n| CKB Testnet Faucet | [faucet.nervos.org](https://faucet.nervos.org) | Get testnet CKB |\n| RUSD Stablecoin | [testnet0815.stablepp.xyz](https://testnet0815.stablepp.xyz/stablecoin) | Mint testnet RUSD |\n| CKB Explorer | [explorer.nervos.org](https://explorer.nervos.org/aggron) | Testnet block explorer |\n| Fiber Dashboard | [dashboard.fiber.channel](https://dashboard.fiber.channel/nodes) | Network topology & stats |\n| Fiber Releases | [GitHub Releases](https://github.com/nervosnetwork/fiber/releases) | Download latest binary |\n\n### Public Testnet Nodes",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-776",
       "title": "Fiber Cheat Code",
-      "content": "```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"send_payment\",\n  \"params\": [{\n    \"target_pubkey\": \"<your_own_pubkey>\",\n    \"amount\": \"0x5F5E100\",\n    \"keysend\": true,\n    \"allow_self_payment\": true\n  }],\n  \"id\": 1\n}\n```\n\n**Manual** — use `build_router` + `send_payment_with_router` for control over the exact path. See [Channel Rebalancing](/docs/concept/channels/channel-rebalancing) for details.\n\n### Keysend Payments\n\nSend a payment without an invoice by specifying the recipient's pubkey directly:\n\n```bash\nfnn-cli payment send_payment --target-pubkey <recipient_pubkey> --amount 100000000 --keysend true\n```",
+      "content": "| Name | Pubkey | Auto-accept CKB | Auto-accept UDT |\n|------|--------|------------------|------------------|\n| fiber-testnet-public-bottle | `02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71` | ≥ 499 CKB | RUSD ≥ 20 |\n| fiber-testnet-public-bracer | `0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc` | ≥ 499 CKB | RUSD ≥ 20 |\n\n## Common Patterns\n\n### Multi-Hop Routing\n\nYou don't need a direct channel to every peer. Fiber automatically discovers paths through intermediate relay nodes:",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-777",
       "title": "Fiber Cheat Code",
-      "content": "Keysend is useful for spontaneous payments, tipping, and machine-to-machine transactions where the recipient cannot pre-generate an invoice. For CKB payments, the CLI amount is in shannons (`100000000` = 1 CKB).\n\n---\n\n**Further reading**:\n\n- [Channel Lifecycle](/docs/concept/channels/channel-lifecycle) — detailed channel state transitions\n- [Payment Lifecycle](/docs/concept/payments/payment-lifecycle) — payment session and attempt states\n- [HTTP RPC Reference](/docs/api-reference) — full RPC API reference\n- [Network Resources](/docs/quick-start/network-resources) — public nodes, faucets, and explorers\n- [Channel Rebalancing](/docs/concept/channels/channel-rebalancing) — liquidity management",
+      "content": "```\n┌───────┐        ┌───────┐        ┌───────┐        ┌───────┐\n│ nodeA │ ─────▶ │ node1 │ ─────▶ │ node2 │ ─────▶ │ nodeB │\n│:8227  │        │public │        │public │        │:8237  │\n└───────┘        └───────┘        └───────┘        └───────┘\n  sender        relay node 1     relay node 2      receiver\n```\n\nLocal nodes do not need a public IP — they connect through public relay nodes. See [Multi-Hop Routing](/docs/concept/routing/multi-hop) for full details.\n\n### Channel Rebalancing\n\nWhen one side of a channel is depleted, rebalance by sending a payment back to yourself:\n\n**Automatic** — use `send_payment` with `allow_self_payment: true`:",
       "url": "/docs/res/cheat-code",
       "source": "docs/res/cheat-code.mdx"
     },
     {
       "id": "chunk-778",
+      "title": "Fiber Cheat Code",
+      "content": "```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"send_payment\",\n  \"params\": [{\n    \"target_pubkey\": \"<your_own_pubkey>\",\n    \"amount\": \"0x5F5E100\",\n    \"keysend\": true,\n    \"allow_self_payment\": true\n  }],\n  \"id\": 1\n}\n```\n\n**Manual** — use `build_router` + `send_payment_with_router` for control over the exact path. See [Channel Rebalancing](/docs/concept/channels/channel-rebalancing) for details.\n\n### Keysend Payments\n\nSend a payment without an invoice by specifying the recipient's pubkey directly:\n\n```bash\nfnn-cli payment send_payment --target-pubkey <recipient_pubkey> --amount 100000000 --keysend true\n```",
+      "url": "/docs/res/cheat-code",
+      "source": "docs/res/cheat-code.mdx"
+    },
+    {
+      "id": "chunk-779",
+      "title": "Fiber Cheat Code",
+      "content": "Keysend is useful for spontaneous payments, tipping, and machine-to-machine transactions where the recipient cannot pre-generate an invoice. For CKB payments, the CLI amount is in shannons (`100000000` = 1 CKB).\n\n---\n\n**Further reading**:\n\n- [Channel Lifecycle](/docs/concept/channels/channel-lifecycle) — detailed channel state transitions\n- [Payment Lifecycle](/docs/concept/payments/payment-lifecycle) — payment session and attempt states\n- [HTTP RPC Reference](/docs/api-reference) — full RPC API reference\n- [Network Resources](/docs/quick-start/network-resources) — public nodes, faucets, and explorers\n- [Channel Rebalancing](/docs/concept/channels/channel-rebalancing) — liquidity management",
+      "url": "/docs/res/cheat-code",
+      "source": "docs/res/cheat-code.mdx"
+    },
+    {
+      "id": "chunk-780",
       "title": "Cross-Chain HTLC",
       "content": "import { Callout } from 'fumadocs-ui/components/callout';\n\n<Callout type=\"info\">\n  This document describes the **Cross-Chain Hub (CCH)** feature in Fiber, which enables atomic swaps between CKB (via Fiber) and Bitcoin (via Lightning Network). If you want to integrate cross-chain payments or run a CCH node, you are in the right place.\n</Callout>\n\n## What Is CCH?\n\n**CCH (Cross-Chain Hub)** is a service built into Fiber that bridges the CKB ecosystem and the Bitcoin Lightning Network using **[Hash Time-Locked Contracts (HTLCs)](/docs/res/glossary#htlc-hashed-timelock-contract)**. It lets users atomically swap wrapped BTC on CKB for native BTC on Lightning, and vice versa — without trusting a third party with custody.",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
-      "id": "chunk-779",
+      "id": "chunk-781",
       "title": "Cross-Chain HTLC",
       "content": "The key guarantee is **atomicity**: either both legs of the swap settle, or neither does. The CCH operator (commonly called *Ingrid* in the literature) cannot steal funds because the same payment hash / preimage locks both sides.\n\n## Why It Matters\n\nFor developers building on Fiber, CCH unlocks several possibilities:\n\n- **Payment interoperability**: A Fiber user can pay compatible [Lightning invoices](/docs/concept/payments/invoice-guide), and a Lightning user can pay compatible [Fiber invoices](/docs/concept/payments/invoice-guide).\n- **Liquidity bootstrapping**: CCH operators can earn fees by providing swap liquidity between the two networks.\n- **No custodial risk**: The swap is enforced by HTLCs on both chains, not by legal contracts.\n\n## Core Concepts\n\n### Shared Payment Hash",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
-      "id": "chunk-780",
+      "id": "chunk-782",
       "title": "Cross-Chain HTLC",
       "content": "Both sides of the swap use the **same SHA-256 payment hash**. The incoming invoice is locked with this hash; the outgoing payment is also locked with the same hash. When the outgoing payment succeeds, the CCH learns the preimage and uses it to settle the incoming invoice.\n\n### Time-Lock Safety\n\nThe CCH must have enough time to claim the outgoing preimage and then settle the incoming invoice before the incoming time lock expires. This is enforced by two rules:",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
-      "id": "chunk-781",
+      "id": "chunk-783",
       "title": "Cross-Chain HTLC",
       "content": "1. **Static check at order creation**: The outgoing invoice's minimum final expiry must be **less than half** of the incoming invoice's final expiry.\n2. **Dynamic check before sending outgoing payment**: After the incoming payment is accepted, the CCH computes the remaining time on the incoming HTLC and caps the outgoing route expiry to at most half of that remaining time.\n\nIf there is insufficient time, the order is failed automatically.\n\n### Wrapped BTC\n\nCCH swaps use a **wrapped BTC UDT** on CKB. The invoice generated by the CCH for CKB payments includes the `udt_type_script` of this wrapped BTC, ensuring the payer knows exactly which token to transfer. The CCH operator configures the wrapped BTC type script via:",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
-      "id": "chunk-782",
-      "title": "Cross-Chain HTLC",
-      "content": "- `wrapped_btc_type_script_args` — the script args (used when Fiber runs in-process)\n- `wrapped_btc_type_script` — the full JSON script (required in standalone mode)\n\n## Architecture\n\nCCH is implemented as a set of cooperating actors inside the Fiber node. Here is the high-level architecture:",
-      "url": "/docs/res/cross-chain-htlc",
-      "source": "docs/res/cross-chain-htlc.mdx"
-    },
-    {
-      "id": "chunk-783",
-      "title": "Cross-Chain HTLC",
-      "content": "```\n┌─────────────────┐     ┌─────────────────┐\n│   CchActor      │────▶│  CchFiberAgent  │──▶ Fiber Network (in-process or RPC)\n│  (main hub)     │     │  (add/send/settle)\n└────────┬────────┘     └─────────────────┘\n         │\n         │ manages\n         ▼\n┌─────────────────┐     ┌─────────────────┐\n│   Scheduler     │     │  ActionDispatcher│\n│ (expiry/prune)  │     │  (execute swaps) │\n└─────────────────┘     └─────────────────┘\n         │                       │\n         │                       ▼\n         │              ┌─────────────────┐\n         │              │  LndTrackerActor │──▶ LND gRPC\n         │              │ (track invoices  │    (Lightning)\n         │              │  & payments)     │\n         │              └─────────────────┘\n         │\n         ▼\n┌─────────────────┐\n│   OrderStore    │──▶ Persistent DB\n│ (CchOrderStore) │\n└─────────────────┘\n```",
-      "url": "/docs/res/cross-chain-htlc",
-      "source": "docs/res/cross-chain-htlc.mdx"
-    },
-    {
       "id": "chunk-784",
       "title": "Cross-Chain HTLC",
-      "content": "### Key Components",
+      "content": "- `wrapped_btc_type_script_args` — the script args (used when Fiber runs in-process)\n- `wrapped_btc_type_script` — the full JSON script (required in standalone mode)\n\n<Callout type=\"info\">\n  **Testnet cWBTC Faucet**: Get free cWBTC test tokens at [faucet-cwbtc.ckb.dev](https://faucet-cwbtc.ckb.dev) to try CCH swaps on testnet without touching mainnet BTC. See [Network Resources](/docs/quick-start/network-resources) for more testnet tools.\n</Callout>\n\n## Architecture\n\nCCH is implemented as a set of cooperating actors inside the Fiber node. Here is the high-level architecture:",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-785",
       "title": "Cross-Chain HTLC",
-      "content": "| Component | Role |\n|-----------|------|\n| `CchActor` | Main actor. Handles RPC requests, manages order lifecycle, subscribes to store changes and tracking events. |\n| `CchFiberAgentRef` | Unified interface to Fiber. Can operate **in-process** (direct actor calls) or over **HTTP RPC** (standalone mode). |\n| `LndTrackerActor` | Tracks Lightning invoices and payments via LND gRPC. Emits `CchTrackingEvent`s back to `CchActor`. |\n| `Scheduler` | Schedules order expiry and final-order pruning using a priority queue. |\n| `ActionDispatcher` | Dispatches concrete actions (`TrackIncomingInvoice`, `SendOutgoingPayment`, `TrackOutgoingPayment`, `SettleIncomingInvoice`) based on order state. |\n| `CchOrderStateMachine` | Pure state machine that transitions orders between statuses based on events. |",
+      "content": "```\n┌─────────────────┐     ┌─────────────────┐\n│   CchActor      │────▶│  CchFiberAgent  │──▶ Fiber Network (in-process or RPC)\n│  (main hub)     │     │  (add/send/settle)\n└────────┬────────┘     └─────────────────┘\n         │\n         │ manages\n         ▼\n┌─────────────────┐     ┌─────────────────┐\n│   Scheduler     │     │  ActionDispatcher│\n│ (expiry/prune)  │     │  (execute swaps) │\n└─────────────────┘     └─────────────────┘\n         │                       │\n         │                       ▼\n         │              ┌─────────────────┐\n         │              │  LndTrackerActor │──▶ LND gRPC\n         │              │ (track invoices  │    (Lightning)\n         │              │  & payments)     │\n         │              └─────────────────┘\n         │\n         ▼\n┌─────────────────┐\n│   OrderStore    │──▶ Persistent DB\n│ (CchOrderStore) │\n└─────────────────┘\n```",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-786",
       "title": "Cross-Chain HTLC",
-      "content": "### Order State Machine\n\nAn order progresses through these statuses:\n\n```\nPending ──▶ IncomingAccepted ──▶ OutgoingInFlight ──▶ OutgoingSuccess ──▶ Success\n              │                    │\n              └────────────────────┴─────────────────────────────────────▶ Failed\n```",
+      "content": "### Key Components",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-787",
       "title": "Cross-Chain HTLC",
-      "content": "| Status | Meaning |\n|--------|---------|\n| `Pending` | Order created. Waiting for the incoming invoice to be paid / accepted. |\n| `IncomingAccepted` | Incoming HTLC has been accepted (e.g., LND hold invoice is `Accepted`, or Fiber invoice is `Received`). Ready to send outgoing payment. |\n| `OutgoingInFlight` | Outgoing payment is in flight. |\n| `OutgoingSuccess` | Outgoing payment settled. Preimage obtained. Ready to settle incoming invoice. |\n| `Success` | Both sides settled. Order complete. |\n| `Failed` | Something went wrong (expired, payment failed, invalid invoice, etc.). |\n\nState transitions are validated by `CchOrderStateMachine::allow_transition`. Invalid transitions are rejected and logged.\n\n### Action Lifecycle\n\nActions are triggered by state changes:",
+      "content": "| Component | Role |\n|-----------|------|\n| `CchActor` | Main actor. Handles RPC requests, manages order lifecycle, subscribes to store changes and tracking events. |\n| `CchFiberAgentRef` | Unified interface to Fiber. Can operate **in-process** (direct actor calls) or over **HTTP RPC** (standalone mode). |\n| `LndTrackerActor` | Tracks Lightning invoices and payments via LND gRPC. Emits `CchTrackingEvent`s back to `CchActor`. |\n| `Scheduler` | Schedules order expiry and final-order pruning using a priority queue. |\n| `ActionDispatcher` | Dispatches concrete actions (`TrackIncomingInvoice`, `SendOutgoingPayment`, `TrackOutgoingPayment`, `SettleIncomingInvoice`) based on order state. |\n| `CchOrderStateMachine` | Pure state machine that transitions orders between statuses based on events. |",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-788",
       "title": "Cross-Chain HTLC",
-      "content": "1. **On order creation** (`on_starting`): `TrackIncomingInvoice` is scheduled.\n2. **On `IncomingAccepted`** (`on_entering`): `SendOutgoingPayment` + `TrackOutgoingPayment` are scheduled.\n3. **On `OutgoingInFlight`** (`on_entering`): `TrackOutgoingPayment` is scheduled (ensures we keep watching).\n4. **On `OutgoingSuccess`** (`on_entering`): `SettleIncomingInvoice` is scheduled.\n5. **On final states** (`Success` / `Failed`): No further actions. Final orders are pruned after their scheduled order expiry time plus an additional 21-day retention period.\n\nActions are executed with **exponential backoff retry** (1 second base, capped at 10 minutes). Permanent errors fail the order immediately; transient errors are retried.\n\n## Two Swap Directions\n\n### Send BTC (CKB → Lightning)",
+      "content": "### Order State Machine\n\nAn order progresses through these statuses:\n\n```\nPending ──▶ IncomingAccepted ──▶ OutgoingInFlight ──▶ OutgoingSuccess ──▶ Success\n              │                    │\n              └────────────────────┴─────────────────────────────────────▶ Failed\n```",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-789",
       "title": "Cross-Chain HTLC",
-      "content": "Alice wants Bob (on Lightning) to receive BTC.",
+      "content": "| Status | Meaning |\n|--------|---------|\n| `Pending` | Order created. Waiting for the incoming invoice to be paid / accepted. |\n| `IncomingAccepted` | Incoming HTLC has been accepted (e.g., LND hold invoice is `Accepted`, or Fiber invoice is `Received`). Ready to send outgoing payment. |\n| `OutgoingInFlight` | Outgoing payment is in flight. |\n| `OutgoingSuccess` | Outgoing payment settled. Preimage obtained. Ready to settle incoming invoice. |\n| `Success` | Both sides settled. Order complete. |\n| `Failed` | Something went wrong (expired, payment failed, invalid invoice, etc.). |\n\nState transitions are validated by `CchOrderStateMachine::allow_transition`. Invalid transitions are rejected and logged.\n\n### Action Lifecycle\n\nActions are triggered by state changes:",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-790",
       "title": "Cross-Chain HTLC",
-      "content": "1. **Bob creates a Lightning invoice** for, say, 10,000 sats.\n2. **Alice calls `send_btc`** with Bob's `btc_pay_req`.\n3. **CCH validates**:\n   - The BTC invoice network matches the CKB network (mainnet ↔ mainnet, testnet ↔ testnet, regtest ↔ regtest).\n   - The BTC invoice has an amount.\n   - The BTC invoice's `min_final_cltv_expiry_delta` is safe relative to CKB's final [TLC](/docs/res/glossary#htlc-hashed-timelock-contract) expiry.\n   - The invoice has not expired and has enough remaining expiry.\n4. **CCH computes the fee**: `fee = base_fee + amount * fee_rate / 1_000_000`.\n5. **CCH creates a Fiber invoice** for `amount + fee` sats, locked with the same `payment_hash`, using the wrapped BTC type script.\n6. **Alice pays the Fiber invoice** through the Fiber network.\n7. **CCH detects the incoming payment** (via store changes or LND tracking).\n8. **CCH sends the outgoing Lightning payment** to Bob's invoice.\n9. **Upon success**, CCH obtains the preimage and settles the Fiber invoice internally.\n10. **Order reaches `Success`**.",
+      "content": "1. **On order creation** (`on_starting`): `TrackIncomingInvoice` is scheduled.\n2. **On `IncomingAccepted`** (`on_entering`): `SendOutgoingPayment` + `TrackOutgoingPayment` are scheduled.\n3. **On `OutgoingInFlight`** (`on_entering`): `TrackOutgoingPayment` is scheduled (ensures we keep watching).\n4. **On `OutgoingSuccess`** (`on_entering`): `SettleIncomingInvoice` is scheduled.\n5. **On final states** (`Success` / `Failed`): No further actions. Final orders are pruned after their scheduled order expiry time plus an additional 21-day retention period.\n\nActions are executed with **exponential backoff retry** (1 second base, capped at 10 minutes). Permanent errors fail the order immediately; transient errors are retried.\n\n## Two Swap Directions\n\n### Send BTC (CKB → Lightning)",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-791",
       "title": "Cross-Chain HTLC",
-      "content": "### Receive BTC (Lightning → CKB)\n\nAlice (on Fiber) wants to receive BTC from Bob (on Lightning).",
+      "content": "Alice wants Bob (on Lightning) to receive BTC.",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-792",
       "title": "Cross-Chain HTLC",
-      "content": "1. **Alice creates a Fiber invoice** for, say, 10,000 wrapped-BTC-sats, using the wrapped BTC type script and `hash_algorithm = sha256`.\n2. **Alice calls `receive_btc`** with her `fiber_pay_req`.\n3. **CCH validates**:\n   - The Fiber invoice currency matches the configured network.\n   - The Fiber invoice has an amount.\n   - The Fiber invoice's `final_tlc_minimum_expiry_delta` is safe relative to BTC's final CLTV expiry.\n   - The invoice's UDT type script matches the configured `wrapped_btc_type_script`.\n   - The hash algorithm is `sha256` (required for LND compatibility).\n4. **CCH computes the fee**: `fee = base_fee + amount * fee_rate / 1_000_000`.\n5. **CCH creates a Lightning hold invoice** via LND for `(amount + fee) * 1000` millisats, locked with the same `payment_hash`.\n6. **Bob pays the Lightning invoice** through the Lightning network.\n7. **LND detects the incoming payment** and emits an `Accepted` event.\n8. **CCH sends the outgoing Fiber payment** to Alice's invoice.\n9. **Upon success**, CCH obtains the preimage from the Fiber payment.\n10. **CCH settles the Lightning hold invoice** with the preimage.\n11. **Order reaches `Success`**.",
+      "content": "1. **Bob creates a Lightning invoice** for, say, 10,000 sats.\n2. **Alice calls `send_btc`** with Bob's `btc_pay_req`.\n3. **CCH validates**:\n   - The BTC invoice network matches the CKB network (mainnet ↔ mainnet, testnet ↔ testnet, regtest ↔ regtest).\n   - The BTC invoice has an amount.\n   - The BTC invoice's `min_final_cltv_expiry_delta` is safe relative to CKB's final [TLC](/docs/res/glossary#htlc-hashed-timelock-contract) expiry.\n   - The invoice has not expired and has enough remaining expiry.\n4. **CCH computes the fee**: `fee = base_fee + amount * fee_rate / 1_000_000`.\n5. **CCH creates a Fiber invoice** for `amount + fee` sats, locked with the same `payment_hash`, using the wrapped BTC type script.\n6. **Alice pays the Fiber invoice** through the Fiber network.\n7. **CCH detects the incoming payment** (via store changes or LND tracking).\n8. **CCH sends the outgoing Lightning payment** to Bob's invoice.\n9. **Upon success**, CCH obtains the preimage and settles the Fiber invoice internally.\n10. **Order reaches `Success`**.",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-793",
       "title": "Cross-Chain HTLC",
-      "content": "## Running a CCH Node\n\n### Configuration\n\nTo run CCH, add `cch` to the `services` list and configure the `cch` section in your Fiber `config.yml` (or provide the equivalent CLI flags / environment variables):\n\n```yaml\nservices:\n  - fiber\n  - rpc\n  - cch\n\ncch:\n  lnd_rpc_url: \"https://127.0.0.1:10009\"\n  lnd_cert_path: \"/path/to/tls.cert\"\n  lnd_macaroon_path: \"/path/to/admin.macaroon\"\n  wrapped_btc_type_script_args: \"0x...\"\n  base_fee_sats: 0\n  fee_rate_per_million_sats: 1\n```",
+      "content": "### Receive BTC (Lightning → CKB)\n\nAlice (on Fiber) wants to receive BTC from Bob (on Lightning).",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-794",
       "title": "Cross-Chain HTLC",
-      "content": "| Config Key | Default | Description |\n|-----------|---------|-------------|\n| `lnd_rpc_url` | `https://127.0.0.1:10009` | LND gRPC endpoint. |\n| `lnd_cert_path` | — | Path to LND TLS certificate. Omit for well-known CAs. |\n| `lnd_macaroon_path` | — | Path to LND macaroon for authentication. |\n| `wrapped_btc_type_script_args` | — | Args for the wrapped BTC UDT type script. Must have 8 decimal places. |\n| `wrapped_btc_type_script` | — | Full JSON type script. **Required in standalone mode.** |\n| `order_expiry_delta_seconds` | 129600 (36h) | How long an order remains active before auto-failure. |\n| `btc_final_tlc_expiry_delta_blocks` | 360 (~60h) | Final hop CLTV expiry for outgoing Lightning invoices. |\n| `ckb_final_tlc_expiry_delta_seconds` | 216000 (60h) | Final hop TLC expiry for outgoing Fiber invoices. |\n| `min_outgoing_invoice_expiry_delta_seconds` | 21600 (6h) | Minimum acceptable expiry for outgoing invoices. |\n| `base_fee_sats` | 0 | Flat fee per swap. |\n| `fee_rate_per_million_sats` | 1 | Proportional fee rate (parts per million). |\n| `fiber_rpc_url` | — | When set, CCH runs as a **standalone service** talking to Fiber over HTTP/WebSocket. |",
+      "content": "1. **Alice creates a Fiber invoice** for, say, 10,000 wrapped-BTC-sats, using the wrapped BTC type script and `hash_algorithm = sha256`.\n2. **Alice calls `receive_btc`** with her `fiber_pay_req`.\n3. **CCH validates**:\n   - The Fiber invoice currency matches the configured network.\n   - The Fiber invoice has an amount.\n   - The Fiber invoice's `final_tlc_minimum_expiry_delta` is safe relative to BTC's final CLTV expiry.\n   - The invoice's UDT type script matches the configured `wrapped_btc_type_script`.\n   - The hash algorithm is `sha256` (required for LND compatibility).\n4. **CCH computes the fee**: `fee = base_fee + amount * fee_rate / 1_000_000`.\n5. **CCH creates a Lightning hold invoice** via LND for `(amount + fee) * 1000` millisats, locked with the same `payment_hash`.\n6. **Bob pays the Lightning invoice** through the Lightning network.\n7. **LND detects the incoming payment** and emits an `Accepted` event.\n8. **CCH sends the outgoing Fiber payment** to Alice's invoice.\n9. **Upon success**, CCH obtains the preimage from the Fiber payment.\n10. **CCH settles the Lightning hold invoice** with the preimage.\n11. **Order reaches `Success`**.",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-795",
       "title": "Cross-Chain HTLC",
-      "content": "### Standalone Mode\n\nCCH can run as a **separate process** from the Fiber node. In this mode:\n\n- `fiber_rpc_url` must point to a running Fiber node's HTTP RPC endpoint.\n- `wrapped_btc_type_script` must be provided as full JSON (the contracts context is not initialized).\n- CCH subscribes to Fiber store changes via WebSocket (`subscribe_store_changes`).\n- Reconnects automatically on WebSocket failure.\n\nThis is useful for scaling or isolating the swap service from the payment routing node.\n\n### In-Process Mode\n\nWhen CCH and Fiber run in the same process (the default if both are configured):\n\n- CCH talks to the `NetworkActor` directly via actor messages.\n- Store changes are propagated through an `OutputPort`, so CCH reacts instantly to invoice and payment updates.\n- No HTTP/WebSocket overhead.",
+      "content": "## Running a CCH Node\n\n### Configuration\n\nTo run CCH, add `cch` to the `services` list and configure the `cch` section in your Fiber `config.yml` (or provide the equivalent CLI flags / environment variables):\n\n```yaml\nservices:\n  - fiber\n  - rpc\n  - cch\n\ncch:\n  lnd_rpc_url: \"https://127.0.0.1:10009\"\n  lnd_cert_path: \"/path/to/tls.cert\"\n  lnd_macaroon_path: \"/path/to/admin.macaroon\"\n  wrapped_btc_type_script_args: \"0x...\"\n  base_fee_sats: 0\n  fee_rate_per_million_sats: 1\n```",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-796",
       "title": "Cross-Chain HTLC",
-      "content": "## RPC API\n\nCCH exposes three JSON-RPC methods. For detailed schema, see the [CCH API Reference](/docs/api-reference/cch).\n\n### `send_btc`\n\nCreate a CCH order to pay a Lightning invoice from CKB.\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"send_btc\",\n  \"params\": {\n    \"btc_pay_req\": \"lnbc100u1p...\",\n    \"currency\": \"Fibb\"\n  },\n  \"id\": 1\n}\n```\n\n### `receive_btc`\n\nCreate a CCH order to receive BTC via a Fiber invoice.\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"receive_btc\",\n  \"params\": {\n    \"fiber_pay_req\": \"fibb1000...\"\n  },\n  \"id\": 1\n}\n```\n\n### `get_cch_order`\n\nPoll an order by payment hash to monitor its status.\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"get_cch_order\",\n  \"params\": {\n    \"payment_hash\": \"0xabcd1234...\"\n  },\n  \"id\": 1\n}\n```\n\n## Security & Safety Mechanisms",
+      "content": "| Config Key | Default | Description |\n|-----------|---------|-------------|\n| `lnd_rpc_url` | `https://127.0.0.1:10009` | LND gRPC endpoint. |\n| `lnd_cert_path` | — | Path to LND TLS certificate. Omit for well-known CAs. |\n| `lnd_macaroon_path` | — | Path to LND macaroon for authentication. |\n| `wrapped_btc_type_script_args` | — | Args for the wrapped BTC UDT type script. Must have 8 decimal places. |\n| `wrapped_btc_type_script` | — | Full JSON type script. **Required in standalone mode.** |\n| `order_expiry_delta_seconds` | 129600 (36h) | How long an order remains active before auto-failure. |\n| `btc_final_tlc_expiry_delta_blocks` | 360 (~60h) | Final hop CLTV expiry for outgoing Lightning invoices. |\n| `ckb_final_tlc_expiry_delta_seconds` | 216000 (60h) | Final hop TLC expiry for outgoing Fiber invoices. |\n| `min_outgoing_invoice_expiry_delta_seconds` | 21600 (6h) | Minimum acceptable expiry for outgoing invoices. |\n| `base_fee_sats` | 0 | Flat fee per swap. |\n| `fee_rate_per_million_sats` | 1 | Proportional fee rate (parts per million). |\n| `fiber_rpc_url` | — | When set, CCH runs as a **standalone service** talking to Fiber over HTTP/WebSocket. |",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-797",
       "title": "Cross-Chain HTLC",
-      "content": "### Preimage Verification\n\nWhen the outgoing payment succeeds, the state machine verifies that the returned preimage hashes to the original `payment_hash` using SHA-256. If there is a mismatch, the order is failed. This prevents a malicious network from tricking the CCH with an incorrect preimage.\n\n### Expiry Cascade\n\nThe CCH guarantees that it always has a **time buffer** to settle the incoming side after the outgoing side succeeds:",
+      "content": "### Standalone Mode\n\nCCH can run as a **separate process** from the Fiber node. In this mode:\n\n- `fiber_rpc_url` must point to a running Fiber node's HTTP RPC endpoint.\n- `wrapped_btc_type_script` must be provided as full JSON (the contracts context is not initialized).\n- CCH subscribes to Fiber store changes via WebSocket (`subscribe_store_changes`).\n- Reconnects automatically on WebSocket failure.\n\nThis is useful for scaling or isolating the swap service from the payment routing node.\n\n### In-Process Mode\n\nWhen CCH and Fiber run in the same process (the default if both are configured):\n\n- CCH talks to the `NetworkActor` directly via actor messages.\n- Store changes are propagated through an `OutputPort`, so CCH reacts instantly to invoice and payment updates.\n- No HTTP/WebSocket overhead.",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-798",
       "title": "Cross-Chain HTLC",
-      "content": "- **Static validation** at order creation ensures the outgoing invoice's final expiry is less than half of the incoming invoice's final expiry.\n- **Dynamic validation** before sending the outgoing payment computes the actual remaining time on the incoming HTLC and caps the outgoing route expiry to half of that. If the remaining time is too short, the order is failed.\n\n### Permanent vs. Transient Errors\n\nActions distinguish between permanent and transient failures:\n\n- **Permanent** (e.g., `invalid payment request`, `invoice expired`, `no path found`, `payment hash mismatch`): The order is failed immediately.\n- **Transient** (e.g., network timeout, LND temporary error): The action is retried with exponential backoff.\n\n### Order Pruning",
+      "content": "## RPC API\n\nCCH exposes three JSON-RPC methods. For detailed schema, see the [CCH API Reference](/docs/api-reference/cch).\n\n### `send_btc`\n\nCreate a CCH order to pay a Lightning invoice from CKB.\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"send_btc\",\n  \"params\": {\n    \"btc_pay_req\": \"lnbc100u1p...\",\n    \"currency\": \"Fibb\"\n  },\n  \"id\": 1\n}\n```\n\n### `receive_btc`\n\nCreate a CCH order to receive BTC via a Fiber invoice.\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"receive_btc\",\n  \"params\": {\n    \"fiber_pay_req\": \"fibb1000...\"\n  },\n  \"id\": 1\n}\n```\n\n### `get_cch_order`\n\nPoll an order by payment hash to monitor its status.\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"get_cch_order\",\n  \"params\": {\n    \"payment_hash\": \"0xabcd1234...\"\n  },\n  \"id\": 1\n}\n```\n\n## Security & Safety Mechanisms",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-799",
       "title": "Cross-Chain HTLC",
-      "content": "Final orders (`Success` or `Failed`) are kept in the database for **21 days** (configurable via `PRUNE_DELAY_SECONDS` in the scheduler) and then automatically deleted. This prevents unbounded database growth.\n\n## Error Reference\n\nCommon errors you may encounter when creating or processing orders:",
+      "content": "### Preimage Verification\n\nWhen the outgoing payment succeeds, the state machine verifies that the returned preimage hashes to the original `payment_hash` using SHA-256. If there is a mismatch, the order is failed. This prevents a malicious network from tricking the CCH with an incorrect preimage.\n\n### Expiry Cascade\n\nThe CCH guarantees that it always has a **time buffer** to settle the incoming side after the outgoing side succeeds:",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-800",
       "title": "Cross-Chain HTLC",
-      "content": "| Error | When It Happens |\n|-------|-----------------|\n| `BTCInvoiceNetworkMismatch` | The Lightning invoice is for a different BTC network than the CKB network maps to. |\n| `CKBInvoiceNetworkMismatch` | The Fiber invoice currency does not match the CCH node's configured network. |\n| `BTCInvoiceFinalTlcExpiryDeltaTooLarge` | The Lightning invoice's CLTV expiry leaves insufficient margin for the CKB side. |\n| `CKBInvoiceFinalTlcExpiryDeltaTooLarge` | The Fiber invoice's TLC expiry leaves insufficient margin for the BTC side. |\n| `OutgoingInvoiceExpiryTooShort` | The invoice expires sooner than `min_outgoing_invoice_expiry_delta_seconds`. |\n| `WrappedBTCTypescriptMismatch` | The Fiber invoice's UDT type script does not match the configured wrapped BTC. |\n| `CKBInvoiceIncompatibleHashAlgorithm` | The Fiber invoice uses a hash algorithm other than SHA-256. |\n| `SendBTCOrderAmountTooLarge` / `ReceiveBTCOrderAmountTooLarge` | Amount or fee calculation overflowed. |\n| `SettledPaymentMissingPreimage` | Outgoing payment reported success but no preimage was returned. |\n| `PreimageHashMismatch` | The returned preimage does not hash to the expected payment hash. |",
+      "content": "- **Static validation** at order creation ensures the outgoing invoice's final expiry is less than half of the incoming invoice's final expiry.\n- **Dynamic validation** before sending the outgoing payment computes the actual remaining time on the incoming HTLC and caps the outgoing route expiry to half of that. If the remaining time is too short, the order is failed.\n\n### Permanent vs. Transient Errors\n\nActions distinguish between permanent and transient failures:\n\n- **Permanent** (e.g., `invalid payment request`, `invoice expired`, `no path found`, `payment hash mismatch`): The order is failed immediately.\n- **Transient** (e.g., network timeout, LND temporary error): The action is retried with exponential backoff.\n\n### Order Pruning",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-801",
       "title": "Cross-Chain HTLC",
-      "content": "## Building on Top of CCH\n\nIf you are a developer integrating cross-chain swaps into your wallet or dApp, here are some practical patterns:\n\n### Polling Loop for Order Status\n\nAfter creating an order, poll `get_cch_order` until the status is terminal:\n\n```rust\nloop {\n    let order = client.get_cch_order(payment_hash).await?;\n    match order.status {\n        CchOrderStatus::Success => break Ok(()),\n        CchOrderStatus::Failed => break Err(order.failure_reason.unwrap_or_default()),\n        _ => tokio::time::sleep(Duration::from_secs(5)).await,\n    }\n}\n```\n\n### Fee Estimation\n\nBefore creating an order, you can estimate the fee locally:\n\n```rust\nlet fee = base_fee + amount * fee_rate / 1_000_000;\n```",
+      "content": "Final orders (`Success` or `Failed`) are kept in the database for **21 days** (configurable via `PRUNE_DELAY_SECONDS` in the scheduler) and then automatically deleted. This prevents unbounded database growth.\n\n## Error Reference\n\nCommon errors you may encounter when creating or processing orders:",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-802",
       "title": "Cross-Chain HTLC",
-      "content": "Both `base_fee_sats` and `fee_rate_per_million_sats` are exposed via the CCH operator's config. A well-designed UI should display the estimated fee to the user before they confirm the swap.\n\n### Wrapped BTC Discovery\n\nThe CCH response includes `wrapped_btc_type_script`. If you are building a wallet that pays CCH-generated Fiber invoices, verify that the invoice's `udt_type_script` matches a known wrapped BTC token. Do not blindly pay invoices with unknown type scripts.\n\n## Source Code Pointers\n\nIf you want to dive deeper into the implementation, here are the key files in the Fiber repository:",
+      "content": "| Error | When It Happens |\n|-------|-----------------|\n| `BTCInvoiceNetworkMismatch` | The Lightning invoice is for a different BTC network than the CKB network maps to. |\n| `CKBInvoiceNetworkMismatch` | The Fiber invoice currency does not match the CCH node's configured network. |\n| `BTCInvoiceFinalTlcExpiryDeltaTooLarge` | The Lightning invoice's CLTV expiry leaves insufficient margin for the CKB side. |\n| `CKBInvoiceFinalTlcExpiryDeltaTooLarge` | The Fiber invoice's TLC expiry leaves insufficient margin for the BTC side. |\n| `OutgoingInvoiceExpiryTooShort` | The invoice expires sooner than `min_outgoing_invoice_expiry_delta_seconds`. |\n| `WrappedBTCTypescriptMismatch` | The Fiber invoice's UDT type script does not match the configured wrapped BTC. |\n| `CKBInvoiceIncompatibleHashAlgorithm` | The Fiber invoice uses a hash algorithm other than SHA-256. |\n| `SendBTCOrderAmountTooLarge` / `ReceiveBTCOrderAmountTooLarge` | Amount or fee calculation overflowed. |\n| `SettledPaymentMissingPreimage` | Outgoing payment reported success but no preimage was returned. |\n| `PreimageHashMismatch` | The returned preimage does not hash to the expected payment hash. |",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-803",
       "title": "Cross-Chain HTLC",
-      "content": "| File | What It Contains |\n|------|------------------|\n| `crates/fiber-lib/src/cch/mod.rs` | Module exports and public types. |\n| `crates/fiber-lib/src/cch/actor.rs` | Main `CchActor`: message handling, `send_btc`, `receive_btc`, store-change mapping. |\n| `crates/fiber-lib/src/cch/order/state_machine.rs` | `CchOrderStateMachine`: validates state transitions. |\n| `crates/fiber-lib/src/cch/actions/` | Action dispatchers and executors for each step of the swap. |\n| `crates/fiber-lib/src/cch/trackers/lnd_trackers.rs` | `LndTrackerActor`: LND invoice/payment tracking with concurrency limits. |\n| `crates/fiber-lib/src/cch/scheduler.rs` | Order expiry and pruning scheduler. |\n| `crates/fiber-lib/src/cch/cch_fiber_agent.rs` | `CchFiberAgentRef`: abstracts in-process vs. HTTP RPC backends. |\n| `crates/fiber-lib/src/cch/config.rs` | `CchConfig` and default constants. |\n| `crates/fiber-lib/src/rpc/cch.rs` | JSON-RPC server implementation. |\n| `crates/fiber-types/src/cch.rs` | Core data types: `CchOrder`, `CchOrderStatus`, `CchInvoice`. |",
+      "content": "## Building on Top of CCH\n\nIf you are a developer integrating cross-chain swaps into your wallet or dApp, here are some practical patterns:\n\n### Polling Loop for Order Status\n\nAfter creating an order, poll `get_cch_order` until the status is terminal:\n\n```rust\nloop {\n    let order = client.get_cch_order(payment_hash).await?;\n    match order.status {\n        CchOrderStatus::Success => break Ok(()),\n        CchOrderStatus::Failed => break Err(order.failure_reason.unwrap_or_default()),\n        _ => tokio::time::sleep(Duration::from_secs(5)).await,\n    }\n}\n```\n\n### Fee Estimation\n\nBefore creating an order, you can estimate the fee locally:\n\n```rust\nlet fee = base_fee + amount * fee_rate / 1_000_000;\n```",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-804",
       "title": "Cross-Chain HTLC",
-      "content": "## Future: PTLC\n\nFiber plans to migrate from HTLC to **[Point Time-Locked Contracts (PTLC)](/docs/res/glossary#ptlc-point-timelock-contract)**, which offer:\n\n- **Improved privacy**: No shared payment hash across hops (the hash is hidden via adaptor signatures).\n- **Reduced on-chain footprint**: Smaller witness data when channels are force-closed.\n- **Enhanced security**: Resistance to wormhole attacks in [multi-hop routing](/docs/concept/routing/multi-hop).\n\nPTLC will replace the SHA-256 hash lock with Schnorr adaptor signatures. Until then, CCH requires `hash_algorithm = Sha256` for LND compatibility.\n\n## Related Topics",
+      "content": "Both `base_fee_sats` and `fee_rate_per_million_sats` are exposed via the CCH operator's config. A well-designed UI should display the estimated fee to the user before they confirm the swap.\n\n### Wrapped BTC Discovery\n\nThe CCH response includes `wrapped_btc_type_script`. If you are building a wallet that pays CCH-generated Fiber invoices, verify that the invoice's `udt_type_script` matches a known wrapped BTC token. Do not blindly pay invoices with unknown type scripts.\n\n## Source Code Pointers\n\nIf you want to dive deeper into the implementation, here are the key files in the Fiber repository:",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-805",
       "title": "Cross-Chain HTLC",
-      "content": "- [Invoice Guide](/docs/concept/payments/invoice-guide) — How Fiber invoices work\n- [Hold Invoice](/docs/concept/payments/hold-invoice) — Deferred settlement for conditional payments\n- [Multi-Hop Routing](/docs/concept/routing/multi-hop) — How payments route through intermediate nodes\n- [Payment Channel Network](/docs/res/payment-channel) — HTLC concepts and security considerations\n- [Glossary](/docs/res/glossary) — Definitions of HTLC, PTLC, and other Fiber terms\n- [CCH API Reference](/docs/api-reference/cch) — Complete RPC schema",
+      "content": "| File | What It Contains |\n|------|------------------|\n| `crates/fiber-lib/src/cch/mod.rs` | Module exports and public types. |\n| `crates/fiber-lib/src/cch/actor.rs` | Main `CchActor`: message handling, `send_btc`, `receive_btc`, store-change mapping. |\n| `crates/fiber-lib/src/cch/order/state_machine.rs` | `CchOrderStateMachine`: validates state transitions. |\n| `crates/fiber-lib/src/cch/actions/` | Action dispatchers and executors for each step of the swap. |\n| `crates/fiber-lib/src/cch/trackers/lnd_trackers.rs` | `LndTrackerActor`: LND invoice/payment tracking with concurrency limits. |\n| `crates/fiber-lib/src/cch/scheduler.rs` | Order expiry and pruning scheduler. |\n| `crates/fiber-lib/src/cch/cch_fiber_agent.rs` | `CchFiberAgentRef`: abstracts in-process vs. HTTP RPC backends. |\n| `crates/fiber-lib/src/cch/config.rs` | `CchConfig` and default constants. |\n| `crates/fiber-lib/src/rpc/cch.rs` | JSON-RPC server implementation. |\n| `crates/fiber-types/src/cch.rs` | Core data types: `CchOrder`, `CchOrderStatus`, `CchInvoice`. |",
       "url": "/docs/res/cross-chain-htlc",
       "source": "docs/res/cross-chain-htlc.mdx"
     },
     {
       "id": "chunk-806",
+      "title": "Cross-Chain HTLC",
+      "content": "## Future: PTLC\n\nFiber plans to migrate from HTLC to **[Point Time-Locked Contracts (PTLC)](/docs/res/glossary#ptlc-point-timelock-contract)**, which offer:\n\n- **Improved privacy**: No shared payment hash across hops (the hash is hidden via adaptor signatures).\n- **Reduced on-chain footprint**: Smaller witness data when channels are force-closed.\n- **Enhanced security**: Resistance to wormhole attacks in [multi-hop routing](/docs/concept/routing/multi-hop).\n\nPTLC will replace the SHA-256 hash lock with Schnorr adaptor signatures. Until then, CCH requires `hash_algorithm = Sha256` for LND compatibility.\n\n## Related Topics",
+      "url": "/docs/res/cross-chain-htlc",
+      "source": "docs/res/cross-chain-htlc.mdx"
+    },
+    {
+      "id": "chunk-807",
+      "title": "Cross-Chain HTLC",
+      "content": "- [Invoice Guide](/docs/concept/payments/invoice-guide) — How Fiber invoices work\n- [Hold Invoice](/docs/concept/payments/hold-invoice) — Deferred settlement for conditional payments\n- [Multi-Hop Routing](/docs/concept/routing/multi-hop) — How payments route through intermediate nodes\n- [Payment Channel Network](/docs/res/payment-channel) — HTLC concepts and security considerations\n- [Glossary](/docs/res/glossary) — Definitions of HTLC, PTLC, and other Fiber terms\n- [CCH API Reference](/docs/api-reference/cch) — Complete RPC schema",
+      "url": "/docs/res/cross-chain-htlc",
+      "source": "docs/res/cross-chain-htlc.mdx"
+    },
+    {
+      "id": "chunk-808",
       "title": "Using fiber-js in a Browser Extension",
       "content": "## Introduction\n\nThis demo verifies whether `@nervosnetwork/fiber-js` can run inside a browser extension.\n\n( fiber-js is a JavaScript wrapper around the Fiber WebAssembly runtime. It starts a Fiber node inside browser workers and exposes JavaScript methods for controlling that node.)\n\nProject repository:\n\nhttps://github.com/joii2020/fiber-browser-extension-demo\n\nCurrent support status:\n\n- Chrome / Chromium-based browsers: supported\n- Firefox: not supported for now\n- Safari (macOS): not supported for now\n\nThe current demo is mainly designed for Chrome / Chromium Manifest V3 extensions.\n\n---\n\n## Overall Extension Structure\n\nIn this demo, `fiber-js` runs inside a hidden Offscreen Document instead of the popup or a normal web page.\n\nThe recommended structure is:",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-807",
+      "id": "chunk-809",
       "title": "Using fiber-js in a Browser Extension",
       "content": "```\npopup / extension page\n↓\nbackground service worker\n↓\nOffscreen Document\n↓\nfiber-js\n```\n\nIn simple terms:\n\n- popup / extension page: handles the user interface;\n- background service worker: receives requests and forwards messages;\n- Offscreen Document: runs `fiber-js`;\n- `fiber-js`: starts the Fiber node and handles related operations.\n\n---\n\n## Why Use an Offscreen Document\n\nThe main reason for using an Offscreen Document is to keep `fiber-js` running in the extension background.\n\nIf `fiber-js` runs in the popup, a normal extension page, or a web page, it may be interrupted when that page is closed. For payments and channel operations, being interrupted midway may cause abnormal states and may even affect transaction results.",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-808",
+      "id": "chunk-810",
       "title": "Using fiber-js in a Browser Extension",
       "content": "An Offscreen Document is not shown to the user, but it can stay alive in the background for a relatively long time. This makes it a better container for running `fiber-js`.\n\nIt also provides a normal page-like `window` / `document` environment, which makes it easier to load WASM, Workers, and other resources.\n\n---\n\n## What the Offscreen Document Does\n\nThe Offscreen Document is mainly responsible for:\n\n- loading `@nervosnetwork/fiber-js`;\n- initializing WASM;\n- creating the Fiber instance;\n- calling `fiber.start()`;\n- storing Fiber runtime state;\n- receiving requests forwarded by the background;\n- returning execution results or error messages.\n\nYou can think of it as the background runtime page for `fiber-js` inside the browser extension.\n\n---\n\n## Extension Call Flow",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-809",
+      "id": "chunk-811",
       "title": "Using fiber-js in a Browser Extension",
       "content": "The call flow for using `fiber-js` in the extension is roughly as follows:\n\n```\n1. The user opens the popup or extension page\n2. The page sends a request to the background service worker\n3. The background checks whether the Offscreen Document already exists\n4. If it does not exist, the background creates the Offscreen Document\n5. The Offscreen Document loads fiber-js\n6. A Fiber instance is created\n7. fiber.start() is called\n8. Later Fiber-related operations are sent to the Offscreen Document through messages\n```\n\nIn other words, the popup does not directly hold the Fiber instance.\n\nThe popup only sends requests, for example:\n\n- start Fiber;\n- query status;\n- connect to a peer.",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-810",
+      "id": "chunk-812",
       "title": "Using fiber-js in a Browser Extension",
       "content": "If invoice creation, invoice payment, channel opening, channel closing, and other operations are supported later, the same structure should be used: the popup sends messages, and the Offscreen Document handles the actual `fiber-js` calls.\n\n---\n\n## Required Configuration\n\n### 1. Chrome Version and Manifest V3\n\nOffscreen Document requires Chrome 109+ and Manifest V3.\n\nIf you write the manifest directly, you can declare the minimum Chrome version:\n\n```json\nminimum_chrome_version: \"109\"\n```\n\nThe current demo only targets Chrome / Chromium MV3 extensions. It does not apply to Firefox or Safari.\n\n### 2. Offscreen Permission\n\nBecause an Offscreen Document is used, the following permission needs to be declared in the manifest:\n\n```json\npermissions: [\"offscreen\"]\n```\n\n---",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-811",
+      "id": "chunk-813",
       "title": "Using fiber-js in a Browser Extension",
       "content": "### 3. WASM and Worker Permissions\n\n`fiber-js` loads WASM and also uses Workers, so CSP needs to be configured:\n\n```json\ncontent_security_policy: {\n  extension_pages: \"script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; object-src 'self';\"\n}\n```\n\nWhere:\n\n- `wasm-unsafe-eval`: allows WASM to run;\n- `worker-src 'self'`: allows Workers inside the extension package to be loaded.\n\n---\n\n### 4. Cross-Origin Isolation Configuration\n\n`fiber-js` needs to use `SharedArrayBuffer` in the browser.\n\nIn Chrome / Chromium extensions, the following fields need to be added to the manifest:\n\n```json\ncross_origin_embedder_policy: {\n  value: \"require-corp\"\n},\n\ncross_origin_opener_policy: {\n  value: \"same-origin\"\n}\n```\n\nYou can use the following code to check whether the environment meets the requirements:",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-812",
+      "id": "chunk-814",
       "title": "Using fiber-js in a Browser Extension",
       "content": "```js\nwindow.crossOriginIsolated === true\ntypeof SharedArrayBuffer === \"function\"\n```\n\nIf these two conditions are not met, `fiber-js` may fail to start properly.\n\n---\n\n### 5. Fiber Key Storage\n\nThe current demo generates a Fiber key inside the Offscreen Document and stores it in that page's own `localStorage`.\n\nThe storage key is:\n\n```\nfiber-extension-demo:fiber-key\n```\n\nOn subsequent startups, the demo reads this key first to avoid generating a new Fiber node identity every time the popup is opened.\n\nIf this key changes on the next startup, `fiber-js` will treat it as a different node identity. Fiber state, channels, and other data associated with the old key may no longer be usable and may not be recoverable.\n\n---\n\n## Example Manifest Configuration\n\nFull configuration example:",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-813",
+      "id": "chunk-815",
       "title": "Using fiber-js in a Browser Extension",
       "content": "```json\nmanifest: {\n  minimum_chrome_version: \"109\",\n\n  permissions: [\"offscreen\"],\n\n  content_security_policy: {\n    extension_pages: \"script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; object-src 'self';\"\n  },\n\n  cross_origin_embedder_policy: {\n    value: \"require-corp\"\n  },\n\n  cross_origin_opener_policy: {\n    value: \"same-origin\"\n  }\n}\n```\n\n---\n\n## Build Notes\n\nDuring packaging, make sure that:\n\n- the `.wasm` file has been included in the extension package;\n- the Worker file can be loaded by extension pages;\n- the manifest includes the `offscreen` permission;\n- the manifest includes the WASM, Worker, and cross-origin isolation configurations.\n\nIf the `.wasm` file is missing, the extension may still be installed, but `fiber-js` may fail to start.",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-814",
+      "id": "chunk-816",
       "title": "Using fiber-js in a Browser Extension",
       "content": "When publishing the demo, it is recommended to clearly mark it as:\n\n```\nChrome / Chromium MV3 only\n```\n\nDo not mark Firefox and Safari as supported targets.\n\n---\n\n## Memory Usage\n\nUse the browser's built-in memory tools to inspect the Offscreen Document page.\n\nCurrent simple test results:\n\n- initial memory usage is about 135 MB;\n- no obvious memory leak was observed in idle state.\n\nOnly the idle scenario has been tested so far.\n\nFurther testing is still needed for:\n\n- long-running usage;\n- repeated starts and stops;\n- repeated connections;\n- channel opening and closing;\n- recovery after abnormal disconnection.\n\n---\n\n## Firefox and Safari (macOS)",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-815",
+      "id": "chunk-817",
       "title": "Using fiber-js in a Browser Extension",
       "content": "Currently, `fiber-js` cannot run in Firefox or Safari as a browser extension. For normal web pages, if COOP/COEP can make `crossOriginIsolated=true`, then the `SharedArrayBuffer` requirement can be satisfied.\n\nThe reason is that the browser implementation of `fiber-js` depends on `SharedArrayBuffer` to share memory between Workers, and uses `Atomics` for synchronization. The Web platform only exposes `SharedArrayBuffer` when `crossOriginIsolated=true`.\n\nIn Chrome / Chromium extensions, cross-origin isolation can be enabled through the extra manifest fields `cross_origin_embedder_policy` and `cross_origin_opener_policy`.",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-816",
+      "id": "chunk-818",
       "title": "Using fiber-js in a Browser Extension",
       "content": "MDN's WebExtension manifest key list does not include descriptions for `cross_origin_embedder_policy` / `cross_origin_opener_policy`. Firefox and Safari also do not currently provide equivalent extension manifest fields like Chrome / Chromium does. Therefore, even if a normal web page can satisfy `crossOriginIsolated=true`, extension pages currently lack an equivalent configuration entry.\n\nRelated Firefox community issues:\n\n- https://bugzilla.mozilla.org/show_bug.cgi?id=1673477\n- https://bugzilla.mozilla.org/show_bug.cgi?id=1750654\n\nNo clearly corresponding Safari issue has been found yet.",
       "url": "/docs/res/fiber-js-browser-extension",
       "source": "docs/res/fiber-js-browser-extension.mdx"
     },
     {
-      "id": "chunk-817",
+      "id": "chunk-819",
       "title": "Fiber Network Glossary",
       "content": "Simple and non-technical explanations of key Fiber Network terminology.\n\n## Asset\nThe value unit that Fiber moves through channels. An asset can be the native CKB token or a user-defined token (UDT) on the Nervos CKB chain. Unless a specific asset type matters, references to \"assets\" in this glossary mean any Fiber-supported token.\n\n## Fiber Network (Lightning-style on CKB)\nThe \"Asset High-Speed Highway\" for the CKB ecosystem. While asset transfers usually wait for block confirmations on-chain, Fiber Network uses Lightning-style channels to move these assets through \"side lanes\" with near-instant speed and negligible fees. Final settlements are only reported back to the CKB mainnet when necessary.",
       "url": "/docs/res/glossary",
       "source": "docs/res/glossary.mdx"
     },
     {
-      "id": "chunk-818",
-      "title": "Fiber Network Glossary",
-      "content": "## Node\nAn \"Asset Transit Station.\" This can be your CKB wallet or a dedicated server. Nodes are the backbone of the fiber network, responsible for maintaining channels and ensuring that assets flow safely to their destinations.\n\n## Payment Channel\nA \"Private Conveyor Belt\" between two nodes. Both parties lock a certain amount of Cells (CKB's version of smart UTXOs) containing assets on the mainnet. Once open, you can slide balances back and forth instantly—like moving beads on an abacus—without touching the main blockchain.",
-      "url": "/docs/res/glossary",
-      "source": "docs/res/glossary.mdx"
-    },
-    {
-      "id": "chunk-819",
-      "title": "Fiber Network Glossary",
-      "content": "## Commitment Transaction\nA \"Latest Settlement Agreement.\" Every time the balance of assets changes in the channel, both parties sign a new agreement. It's your safety net: if your partner disappears, you can submit this latest agreement to the CKB mainnet to reclaim your Cells and assets.\n\n## Gossip Protocol\nThe \"Status Broadcast.\" Since Fiber Network is decentralized, nodes \"gossip\" to share info: \"I have a channel open,\" or \"I support routing this specific asset.\" This lets nodes build a route map. Gossip shares channel presence and fees—not real-time balances—so a path found this way can still lack capacity.",
-      "url": "/docs/res/glossary",
-      "source": "docs/res/glossary.mdx"
-    },
-    {
       "id": "chunk-820",
       "title": "Fiber Network Glossary",
-      "content": "## Multi-hop Routing\nThe \"Asset Relay Race.\" You don't need a direct channel with everyone. If you want to send assets to someone you aren't connected to, the network finds a path through intermediate nodes, \"hopping\" the assets from channel to channel until they reach the destination.\n\n## Onion Routing\nA \"Multi-Layered Privacy Wrap.\" When you send assets, the route is encrypted in layers. Each intermediate node only knows where to pass the \"package\" next, they don't know where it started or where it's finally going, keeping your financial activity private.",
+      "content": "## Node\nAn \"Asset Transit Station.\" This can be your CKB wallet or a dedicated server. Nodes are the backbone of the fiber network, responsible for maintaining channels and ensuring that assets flow safely to their destinations.\n\n## Payment Channel\nA \"Private Conveyor Belt\" between two nodes. Both parties lock a certain amount of Cells (CKB's version of smart UTXOs) containing assets on the mainnet. Once open, you can slide balances back and forth instantly—like moving beads on an abacus—without touching the main blockchain.",
       "url": "/docs/res/glossary",
       "source": "docs/res/glossary.mdx"
     },
     {
       "id": "chunk-821",
       "title": "Fiber Network Glossary",
-      "content": "## Preimage\nThe \"Digital Claim Ticket.\" This is a secret random string generated by the recipient. It acts as the only key that can unlock the payment. Whoever presents the correct Preimage according to the contract rules gets to claim the assets in the channel.\n\n## TLC (Time Locked Contract)\nA \"Timed Vault\" used inside Fiber channels. A TLC locks a specific amount of assets with two conditions: \"If the recipient presents the correct Preimage before the deadline, the assets are released to them. If the deadline passes, the assets return to the sender.\" TLCs are the fundamental building block that makes multi-hop routing and conditional payments possible on Fiber — the concept is equivalent to an HTLC on the Bitcoin Lightning Network, but implemented on CKB.",
+      "content": "## Commitment Transaction\nA \"Latest Settlement Agreement.\" Every time the balance of assets changes in the channel, both parties sign a new agreement. It's your safety net: if your partner disappears, you can submit this latest agreement to the CKB mainnet to reclaim your Cells and assets.\n\n## Gossip Protocol\nThe \"Status Broadcast.\" Since Fiber Network is decentralized, nodes \"gossip\" to share info: \"I have a channel open,\" or \"I support routing this specific asset.\" This lets nodes build a route map. Gossip shares channel presence and fees—not real-time balances—so a path found this way can still lack capacity.",
       "url": "/docs/res/glossary",
       "source": "docs/res/glossary.mdx"
     },
     {
       "id": "chunk-822",
       "title": "Fiber Network Glossary",
-      "content": "## HTLC (Hashed Timelock Contract)\nA \"Timed Vault with a Passcode.\" The sender locks assets in a box with two rules: \"If you show the 'Claim Ticket' (Preimage) within a certain time, the assets are yours. If the timer runs out, the assets fly back to me.\" This ensures middlemen can't run away with the money.\n\n## PTLC (Point Timelock Contract)\nThe \"Mathematical Upgrade\" to HTLC. In a PTLC, the lock is a curve point (like a public key) rather than a hash, so the secret acts like a private key. This removes the repeated-hash linkage, improving privacy and enabling cleaner multi-path/swap designs. PTLC support is a planned direction; today Fiber still runs on hash-based TLC/HTLC flows.",
+      "content": "## Multi-hop Routing\nThe \"Asset Relay Race.\" You don't need a direct channel with everyone. If you want to send assets to someone you aren't connected to, the network finds a path through intermediate nodes, \"hopping\" the assets from channel to channel until they reach the destination.\n\n## Onion Routing\nA \"Multi-Layered Privacy Wrap.\" When you send assets, the route is encrypted in layers. Each intermediate node only knows where to pass the \"package\" next, they don't know where it started or where it's finally going, keeping your financial activity private.",
       "url": "/docs/res/glossary",
       "source": "docs/res/glossary.mdx"
     },
     {
       "id": "chunk-823",
       "title": "Fiber Network Glossary",
-      "content": "## Invoice\nA \"Digital Bill\" or QR code. When you want to receive a payment, you generate an invoice. It contains the asset type, the amount, an expiry, and a lock derived from a secret (a payment hash today, or a point in a PTLC future). The sender scans it, and Fiber Network automatically finds the best path to pay you.\n\n## Routing Fee\nThe \"Asset Handling Fee.\" Intermediate nodes lock up their own liquidity to forward your payment. The payer covers a small fee (in the asset being moved) as compensation.",
+      "content": "## Preimage\nThe \"Digital Claim Ticket.\" This is a secret random string generated by the recipient. It acts as the only key that can unlock the payment. Whoever presents the correct Preimage according to the contract rules gets to claim the assets in the channel.\n\n## TLC (Time Locked Contract)\nA \"Timed Vault\" used inside Fiber channels. A TLC locks a specific amount of assets with two conditions: \"If the recipient presents the correct Preimage before the deadline, the assets are released to them. If the deadline passes, the assets return to the sender.\" TLCs are the fundamental building block that makes multi-hop routing and conditional payments possible on Fiber — the concept is equivalent to an HTLC on the Bitcoin Lightning Network, but implemented on CKB.",
       "url": "/docs/res/glossary",
       "source": "docs/res/glossary.mdx"
     },
     {
       "id": "chunk-824",
       "title": "Fiber Network Glossary",
-      "content": "## Watchtower\nYour \"Asset Bodyguard.\" Since channel asset states are stored off-chain, a dishonest partner might try to broadcast an \"old agreement\" to steal funds while you are offline. A Watchtower monitors the CKB chain 24/7 and automatically intercepts any cheating attempts, punishing the attacker.",
+      "content": "## HTLC (Hashed Timelock Contract)\nA \"Timed Vault with a Passcode.\" The sender locks assets in a box with two rules: \"If you show the 'Claim Ticket' (Preimage) within a certain time, the assets are yours. If the timer runs out, the assets fly back to me.\" This ensures middlemen can't run away with the money.\n\n## PTLC (Point Timelock Contract)\nThe \"Mathematical Upgrade\" to HTLC. In a PTLC, the lock is a curve point (like a public key) rather than a hash, so the secret acts like a private key. This removes the repeated-hash linkage, improving privacy and enabling cleaner multi-path/swap designs. PTLC support is a planned direction; today Fiber still runs on hash-based TLC/HTLC flows.",
       "url": "/docs/res/glossary",
       "source": "docs/res/glossary.mdx"
     },
     {
       "id": "chunk-825",
+      "title": "Fiber Network Glossary",
+      "content": "## Invoice\nA \"Digital Bill\" or QR code. When you want to receive a payment, you generate an invoice. It contains the asset type, the amount, an expiry, and a lock derived from a secret (a payment hash today, or a point in a PTLC future). The sender scans it, and Fiber Network automatically finds the best path to pay you.\n\n## Routing Fee\nThe \"Asset Handling Fee.\" Intermediate nodes lock up their own liquidity to forward your payment. The payer covers a small fee (in the asset being moved) as compensation.",
+      "url": "/docs/res/glossary",
+      "source": "docs/res/glossary.mdx"
+    },
+    {
+      "id": "chunk-826",
+      "title": "Fiber Network Glossary",
+      "content": "## Watchtower\nYour \"Asset Bodyguard.\" Since channel asset states are stored off-chain, a dishonest partner might try to broadcast an \"old agreement\" to steal funds while you are offline. A Watchtower monitors the CKB chain 24/7 and automatically intercepts any cheating attempts, punishing the attacker.",
+      "url": "/docs/res/glossary",
+      "source": "docs/res/glossary.mdx"
+    },
+    {
+      "id": "chunk-827",
       "title": "Gossip Protocol",
       "content": "This note documents the **Fiber** gossip subsystem from an engineering perspective.\n\n## 1. What Gossip Solves\n\nFiber nodes need a shared(ish) view of the network to do routing and validation:\n\n- **Node information** (identity, addresses, feature bits).\n- **Public channels** (existence of an edge between two nodes).\n- **Channel state updates** (fee policy, HTLC constraints, enabled/disabled, direction).\n\nIn a decentralized network:\n\n- Each node connects to only a small subset of peers.\n- Peers can disconnect, partitions happen, nodes restart.\n- Peers can be malicious (spam, eclipse-style isolation).\n\nSo gossip must provide:",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-826",
+      "id": "chunk-828",
       "title": "Gossip Protocol",
       "content": "- **Catch-up (history sync)** after downtime or partitions.\n- **Incremental updates (subscription)** once caught up.\n- **Verification and dependency handling** so \"received\" does not automatically mean \"accepted/applied\".\n- **Resource bounds** (rate limiting, peer targeting) for safety and scalability.\n\n---\n\n## 2. Key Concepts in Fiber\n\n### 2.1 Broadcast messages and the Cursor\n\nFiber treats gossip as an **ordered stream** of broadcast messages.\n\n- Messages are stored with a monotonic ordering key called a **Cursor**.\n- Conceptually: `Cursor = (timestamp, message_id)`.\n\nThis enables a clean primitive:\n\n- \"Give me messages **after** cursor X, up to N items.\"\n\nThis is implemented by the `GossipMessageStore` trait in `gossip.rs`, backed by the DB store.",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-827",
+      "id": "chunk-829",
       "title": "Gossip Protocol",
       "content": "### 2.2 Two sync modes: active vs passive\n\nFiber tracks per-peer sync state via `PeerSyncStatus` (in `gossip.rs`).\n\n- **Active syncing (pull history)**\n  - State: `ActiveGet(...)`\n  - Mechanism: repeatedly send `GetBroadcastMessages(after_cursor, count)` and advance the cursor.\n  - Completion: when the peer returns an empty batch, the peer is considered \"caught up\".\n\n- **Passive syncing (subscribe/push updates)**\n  - State: `PassiveFilter(cursor)`\n  - Mechanism: send `BroadcastMessagesFilter(after_cursor)` so the peer pushes updates.\n  - Goal: reduce silos and keep the node up-to-date without constant pulling.\n\nThese are not competing modes; they are typically used in phases:\n\n1. Active sync with a limited number of peers to catch up.\n2. Passive subscriptions to keep up continuously.\n\n---",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-828",
+      "id": "chunk-830",
       "title": "Gossip Protocol",
       "content": "## 3. Architecture: Main Components\n\n### 3.1 Actors and responsibilities\n\nFiber splits the gossip subsystem into a few cooperating actors:\n\n- `GossipActor` (control plane)\n  - Tracks connected peers and their `PeerSyncStatus`.\n  - Decides which peers to actively sync vs passively subscribe.\n  - Routes incoming protocol messages to the right internal component.\n  - Triggers periodic maintenance (network tick, pruning stale messages).\n\n- `GossipSyncingActor` (data plane for active syncing)\n  - Dedicated per-peer worker for **pulling history**.\n  - Sends `GetBroadcastMessages` and processes `GetBroadcastMessagesResult`.\n  - On completion, notifies `GossipActor`.",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-829",
+      "id": "chunk-831",
       "title": "Gossip Protocol",
       "content": "- `PeerFilterProcessor` (subscription management)\n  - Manages subscription filters for peers.\n  - Updates the store subscription cursor when a peer changes `after_cursor`.\n\n- `ExtendedGossipMessageStore` (store actor + fan-out)\n  - Receives batches of messages from `GossipActor` and saves them.\n  - Performs dependency/ordering handling (important for correctness).\n  - Fans out `GossipMessageUpdates` to subscribers.\n\n### 3.2 Where NetworkGraph fits\n\n`NetworkActor` subscribes to gossip store updates and applies them into `NetworkGraph`.\nThis is the primary pipeline that turns \"gossip messages\" into \"routing graph state\".\n\n---\n\n## 4. Relationship Diagram (Network + Gossip + Store)",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-830",
+      "id": "chunk-832",
       "title": "Gossip Protocol",
       "content": "```mermaid\nflowchart LR\n  subgraph P2P[P2P Service]\n    Sess[Session / Peer]\n    GossipProto[GossipProtocolHandle]\n    FiberProto[FiberProtocolHandle]\n  end\n\n  subgraph Net[fiber/network.rs]\n    NA[NetworkActor]\n  end\n\n  subgraph Gossip[fiber/gossip.rs]\n    GA[GossipActor]\n    GSA[GossipSyncingActor]\n    PFP[PeerFilterProcessor]\n    ES[ExtendedGossipMessageStore Actor]\n  end\n\n  subgraph Store[store/store_impl]\n    DB[Store DB]\n  end\n\n  subgraph Graph[fiber/graph.rs]\n    NG[NetworkGraph]\n  end\n\n  subgraph Chain[ckb]\n    CA[CkbChainActor]\n  end\n\n  Sess --> GossipProto\n  Sess --> FiberProto\n\n  GossipProto -->|PeerConnected| GA\n  GossipProto -->|GossipMessageReceived| GA\n\n  NA -->|BroadcastMessages| GA\n  GA -->|SaveAndBroadcastMessages| ES\n  GA -->|SaveMessages| ES",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-831",
+      "id": "chunk-833",
       "title": "Gossip Protocol",
       "content": "GA -->|start active sync| GSA\n  GSA -->|GetBroadcastMessages| GossipProto\n  GossipProto -->|GetBroadcastMessagesResult| GA\n  GA -->|ResponseReceived| GSA\n  GSA -->|SaveMessages| ES\n  GSA -->|ActiveSyncingFinished| GA\n\n  GA -->|BroadcastMessagesFilter| GossipProto\n  GossipProto -->|BroadcastMessagesFilter| GA\n  GA -->|spawn/update| PFP\n  PFP -->|UpdateSubscription| ES\n  ES -->|BroadcastMessagesFilterResult| GossipProto\n  GossipProto -->|BroadcastMessagesFilterResult| GA\n\n  ES -->|persist/read| DB\n\n  NA -->|subscribe store updates| ES\n  ES -->|GossipMessageUpdates| NA\n  NA -->|apply updates| NG\n\n  GA -->|verify deps| CA\n  GSA -->|verify deps| CA\n```\n\n---\n\n## 5. Primary Data Flows\n\n### 5.1 Local broadcast (originating messages)",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-832",
+      "id": "chunk-834",
       "title": "Gossip Protocol",
       "content": "When Fiber produces a local broadcast message (e.g., node announcement or public channel messages),\n`NetworkActor` sends it into gossip via `GossipActorMessage::TryBroadcastMessages(...)`.\n\n`GossipActor` passes these to `ExtendedGossipMessageStore` (save + fan-out) and to peers.\n\n### 5.2 Active syncing (pull history)\n\nActive syncing is driven by `GossipSyncingActor`:\n\n1. Start with a cursor.\n2. Send `GetBroadcastMessages(after_cursor)`.\n3. Receive `GetBroadcastMessagesResult(messages)`.\n4. Save messages into store, advance cursor.\n5. Repeat until empty result.\n\n### 5.3 Passive syncing (subscribe/push)\n\nPassive syncing is filter-based:",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-833",
+      "id": "chunk-835",
       "title": "Gossip Protocol",
       "content": "1. Send `BroadcastMessagesFilter(after_cursor)` to a peer.\n2. The peer responds over time with `BroadcastMessagesFilterResult(messages)`.\n3. Save messages into store.\n\nThis is how a node stays updated after catching up.\n\n---\n\n## 6. Notes and Pitfalls\n\n### 6.1 \"Received\" does not mean \"Applied\"\n\nThe observable pipeline is:\n\n1. Protocol receives a gossip message.\n2. `GossipActor` routes it.\n3. Store verifies / checks dependencies / persists.\n4. Subscribers receive `GossipMessageUpdates`.\n5. `NetworkGraph` applies updates.\n\nIf any step drops or delays a message, you can see logs like \"received X\" without seeing the graph change.\n\n### 6.2 Immutable vs mutable messages",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-834",
+      "id": "chunk-836",
       "title": "Gossip Protocol",
       "content": "Some messages are effectively immutable and may be broadcast only once (e.g., channel announcements).\nIf your sync strategy starts from a cursor that is too new, you can miss these older-but-still-relevant\nmessages permanently.\n\nBy contrast, node announcements or channel updates tend to refresh over time, so missing one update is\noften healed by later updates.\n\n### 6.3 Cursor selection and \"safe\" cursors\n\nFiber uses the concept of a \"safe_cursor\" to avoid syncing from genesis forever. This is practical,\nbut it must be chosen carefully:\n\n- Too old → bandwidth waste.\n- Too new → can miss important older messages.\n\nThis trade-off becomes visible when bridging two previously disconnected clusters.\n\n### 6.4 Dependency and ordering\n\nChannel-related updates can depend on:",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-835",
+      "id": "chunk-837",
       "title": "Gossip Protocol",
       "content": "- Having a channel announcement present.\n- Having chain/onchain info available.\n- Satisfying timestamp and signature constraints.\n\nA robust store layer typically needs to handle out-of-order arrival and cache/resolve dependencies.\n\n### 6.5 Eclipse-resistance considerations\n\nFiber distinguishes targeted **outbound** passive syncing peers to reduce eclipse risk. Practical\nnotes:\n\n- Prefer maintaining subscriptions with multiple independent outbound peers.\n- Limit concurrent active syncing peers to bound bandwidth and CPU.\n\n---\n\n## 7. References (code)",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-836",
+      "id": "chunk-838",
       "title": "Gossip Protocol",
       "content": "- Gossip protocol + actors: `crates/fiber-lib/src/fiber/gossip.rs`\n- Network startup + subscription wiring: `crates/fiber-lib/src/fiber/network.rs`\n- Persistent storage for broadcast messages: `crates/fiber-lib/src/store/store_impl/mod.rs`\n- Graph application of gossip updates: `crates/fiber-lib/src/fiber/graph.rs`",
       "url": "/docs/res/gossip-protocol",
       "source": "docs/res/gossip-protocol.mdx"
     },
     {
-      "id": "chunk-837",
+      "id": "chunk-839",
       "title": "Fiber Architecture & Module",
       "content": "## Overview\n\nFiber is a Lightning-compatible peer-to-peer payment and swap network built on CKB, the base layer of [Nervos Network](https://www.nervos.org/). Fiber is designed to enable fast, secure, and efficient off-chain payment solutions, particularly for **micropayments** and **high-frequency** transactions.\n\nInspired by Bitcoin’s Lightning Network, Fiber leverages CKB’s unique architecture and offers the following key features:",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-838",
+      "id": "chunk-840",
       "title": "Fiber Architecture & Module",
       "content": "- **Multi-Asset Support**: Fiber is not limited to a single currency; it supports transactions involving multiple assets, paving the way for complex cross-chain financial applications.\n- **Cross-Chain Interoperability**: Fiber is natively designed to interact with Lightning Networks on other UTXO-based blockchains (such as Bitcoin), improving cross-chain asset liquidity and network compatibility.\n- **Flexible State Management**: Thanks to CKB’s Cell model, Fiber efficiently manages channel states, reducing the complexity of off-chain interactions.\n- **Programmability**: Built on CKB’s Turing-complete smart contracts architecture, Fiber enables more complex conditional execution and transaction rules, extending the use cases of payment channels.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-839",
+      "id": "chunk-841",
       "title": "Fiber Architecture & Module",
       "content": "This article presents a **source code-level** exploration of Fiber's architecture, key modules, as well as an overview of its future development plans.\n\n## **Prerequisites**",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-840",
+      "id": "chunk-842",
       "title": "Fiber Architecture & Module",
       "content": "- **Rust and Actor Framework**: Fiber is entirely implemented in Rust and follows the [Actor Model](https://github.com/slawlor/ractor) programming paradigm. It relies on the community-maintained [slawlor/ractor](https://github.com/slawlor/ractor) framework.\n- **Lightning Network**: Fiber follows the core principles of Lightning Network. Resources such as [*Mastering the Lightning Network*](https://github.com/lnbook/lnbook) and [BOLTs](https://github.com/lightning/bolts) are highly recommended for understanding the concepts.\n- **CKB Transactions and Contracts**: Fiber interacts with CKB nodes via RPC, making a solid understanding of [CKB contract](https://docs.nervos.org/docs/script/intro-to-script) development essential.\n\n## Key Modules",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-841",
+      "id": "chunk-843",
       "title": "Fiber Architecture & Module",
       "content": "At a high level, a Fiber node consists of several key modules:\n\n![image](/imgs/docs/high-level/key-module.png)\n\n### Overview",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-842",
+      "id": "chunk-844",
       "title": "Fiber Architecture & Module",
       "content": "- **Network Actor:** Facilitates communication between nodes and channels, managing both internal and external messages along with related management operations.\n- **Network Graph**: Maintains a node’s view of the entire network, storing data on all nodes and channels while dynamically updating through gossip messages. When receiving a payment request, a node uses the network graph to find a route to the recipient.\n- **PaymentSession**: Manages the lifecycle of a payment.\n- [**fiber-sphinx**](https://github.com/cryptape/fiber-sphinx) : A Rust library for [Onion](https://en.wikipedia.org/wiki/Onion_routing) packet encryption and decryption. In Fiber, this ensures sensitive payment details are hidden from intermediate nodes, enhancing security and anonymity.\n- **Gossip**: A protocol for sharing channel/node information, facilitating payment path discovery and updates.\n- **Watchtower**: Monitors channels for fraudulent transactions. If a peer submits an outdated commitment transaction, the watchtower issues a revocation transaction as a penalty.\n- **Cross Hub**: Enables cross-chain interoperability. For example, a payer can send Bitcoin through the Lightning Network, while the recipient receives CKB. The cross hub handles the conversion, mapping Bitcoin payments and invoices to Fiber’s system.\n- [**Fiber-Scripts**](https://github.com/nervosnetwork/fiber-scripts/tree/main): A separate repository containing two main contracts:\n    - [**Funding Lock**](https://github.com/nervosnetwork/fiber-scripts/tree/main/contracts/funding-lock): A contract for locking funds, utilizing the `ckb-auth` library to implement a 2-of-2 multi-signature scheme for channel funding.\n    - [**Commitment Lock**](https://github.com/nervosnetwork/fiber-scripts/tree/main/contracts/commitment-lock): Implements the [Daric](https://eprint.iacr.org/2022/1295) protocol as Fiber’s penalty mechanism to achieve optimal storage and bounded closure.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-843",
+      "id": "chunk-845",
       "title": "Fiber Architecture & Module",
       "content": "### Efficient Channel Management with the Actor Model\n\nThe Lightning Network is essentially a peer-to-peer (P2P) system, where nodes communicate via network messages, updating internal states accordingly. The Actor Model aligns well with this setup:\n\n![image](/imgs/docs/high-level/actor-model.png)\n\nOne potential concern with the Actor Model is its **memory footprint** and **runtime efficiency**. We conducted a [performance test](https://github.com/contrun/ractor/blob/a74cc0f6f9e2b4699991fc9902f10a59f06e4ed8/ractor/examples/bench_memory_usage.rs), showing that 0.9 GB of memory can support 100,000 actors (each with a 1 KB state), processing 100 messages per actor within 10 seconds—demonstrating acceptable performance.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-844",
+      "id": "chunk-846",
       "title": "Fiber Architecture & Module",
       "content": "Unlike `rust-lightning`, which relies on complex [locking mechanisms](https://github.com/lightningdevkit/rust-lightning/blob/b8b1ef3149f26992625a03d45c0307bfad70e8bd/lightning/src/ln/channelmanager.rs#L1167) to maintain data consistency, Fiber’s Actor Model simplifies implementation by eliminating the need for locks to protect data updates. Messages are processed sequentially in an actor’s message queue. When a message handler completes its tasks, the updated [channel state is written to the database](https://github.com/nervosnetwork/fiber/blob/81014d36502b76e2637dfa414b5a3ee494942c41/src/fiber/channel.rs#L2276), streamlining the persistence process.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-845",
+      "id": "chunk-847",
       "title": "Fiber Architecture & Module",
       "content": "Almost all modules in Fiber use the Actor Model. The [Network Actor](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L694-L789) handles communication both within and across nodes. For example, if Node A wants to send an \"Open Channel\" message to Node B, the process follows these steps:\n\n1. The `Channel Actor` in Node A (`Actor 0` in this case) sends the message to the `Network Actor` in Node B.\n2. The `Network Actor` transmits the message using [Tentacle](https://github.com/nervosnetwork/tentacle/tree/master), a lower-level networking layer.\n3. The `Network Actor` in Node B receives the message and forwards it to the corresponding `Channel Actor`(`Actor 0/1/…/n`).\n\n![image](/imgs/docs/high-level/actor-1.png)",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-846",
+      "id": "chunk-848",
       "title": "Fiber Architecture & Module",
       "content": "For each new channel, Fiber creates a corresponding [ChannelActor](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/channel.rs#L301-L308), where the `ChannelActorState` maintains all the necessary data for the channel.\n\nAnother major advantage of the Actor Model is its ability to map **HTLC (Hash Time-Locked Contracts)**-related operations directly to specific functions. For example, in the process of forwarding an HTLC across multiple nodes:",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-847",
+      "id": "chunk-849",
       "title": "Fiber Architecture & Module",
       "content": "- Node A’s `Actor 0` handles the `AddTlc` operation via [handle_add_tlc_command](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/channel.rs#L1251).\n- Node B’s `Actor 1` handles the corresponding peer message via [handle_add_tlc_peer_message](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/channel.rs#L1069).\n\n![image](/imgs/docs/high-level/actor-2.png)\n\nThe **HTLC management** within channels is one of the most complex aspects of the Lightning Network, primarily due to the dependency of channel state changes on peer interactions. Both sides of a channel can have simultaneous HTLC operations.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-848",
+      "id": "chunk-850",
       "title": "Fiber Architecture & Module",
       "content": "Fiber adopts `rust-lightning`’s approach of using a [state machine to track HTLC states](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/channel.rs#L2463-L2496), where state transitions occur based on `commitment_sign` and `revoke_and_ack` messages. The `AddTlc` operation and state transitions for both peers are as follows:\n\n![image](/imgs/docs/high-level/htlc.png)\n\n### Optimized Payment Processing and Multi-Hop Routing\n\nEach Fiber node maintains a representation of the network through a **Network Grap**, essentially a **bidirectional directed graph**, where:\n\n- Each **Fiber node** represents a **vertex**.\n- Each **channel** represents an **edge**.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-849",
+      "id": "chunk-851",
       "title": "Fiber Architecture & Module",
       "content": "For privacy reasons, the actual balance partition of a channel is not broadcasted across the network. Instead, the edge weight represents the channel capacity.\n\nBefore initiating a payment, the sender performs pathfinding to discover a route to the recipient. If multiple paths available, the sender must determine the optimal one by considering various factors. Finding the best path in a graph with incomplete information is a complex engineering challenge. A detailed discussion of this issue can be found in [*Mastering Lightning Network*](https://github.com/lnbook/lnbook/blob/develop/12_path_finding.asciidoc#pathfinding-what-problem-are-we-solving).\n\n![image](/imgs/docs/high-level/multihop.png)",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-850",
+      "id": "chunk-852",
       "title": "Fiber Architecture & Module",
       "content": "In Fiber, users initiate payments via [RPC requests](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/rpc/payment.rs#L171-L209). When a node receives a payment request, it creates a corresponding [PaymentSession](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L1866-L1871) to track the payment lifecycle.\n\nThe quality of pathfinding directly impacts network efficiency and payment success rates. Currently, Fiber uses a variant of [Dijkstra’s algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm). The implementation can be found [here](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/graph.rs#L914-L925).",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-851",
+      "id": "chunk-853",
       "title": "Fiber Architecture & Module",
       "content": "However, unlike the standard Dijkstra algorithm, Fiber’s routing expands **backward from the target** toward the source. During the search, the algorithm considers multiple factors:\n\n- Payment success probability\n- Transaction fee\n- HTLC lock time\n\nRoutes are ranked by computing a [distance metric](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/graph.rs#L1110). **Probability estimation** is derived from past payment results and analysis, implemented in the [eval_probability module](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/history.rs#L481-L506).",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-852",
+      "id": "chunk-854",
       "title": "Fiber Architecture & Module",
       "content": "Once the path is determined, the next step is to [construct an Onion Packet](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L1634-L1656). Then the source node sends an [AddTlcCommand](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L1657-L1667) to start the payment. The payment status will be updated asynchronously. Whether the HTLC succeeds or fails, the network actor processes the result [via event notifications](https://github.com/nervosnetwork/fiber/blob/b5c38a800e94aaa368a4c8a8699f5db0c08ecfbd/src/fiber/network.rs#L1501-L1507).\n\n### Reliable Payment Retries and Failure Handling",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-853",
+      "id": "chunk-855",
       "title": "Fiber Architecture & Module",
       "content": "Payments in Fiber may require **multiple retries** due to various factors, with a common failure scenario being:\n\n- The **channel capacity** used in the Network Graph is an **upper bound**.\n- The actual **available liquidity** might be **insufficient** to complete the payment.\n\nWhen a payment fails due to liquidity constraints:\n\n- The system **returns an error** and **updates** the **Network Graph**.\n- The node **automatically initiates** [a new pathfinding attempt](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L1767-L1772).\n\nThis **dynamic retry mechanism** ensures that payments have a **higher chance of success** despite fluctuating network conditions.\n\n### Peer Broadcasting with Gossip Protocol",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-854",
+      "id": "chunk-856",
       "title": "Fiber Architecture & Module",
       "content": "Fiber nodes exchange information about **new nodes** and **channels** by broadcasting messages. The [Gossip module](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/gossip.rs#L293-L331) implements the [routing gossip protocol defined in BOLTs 7](https://github.com/lightning/bolts/blob/master/07-routing-gossip.md).  The key technical decisions were documented in the PR: [Refactor gossip protocol](https://github.com/nervosnetwork/fiber/pull/308).\n\nWhen a node starts for the first time, it connects to its initial peers using addresses specified in the configuration file under [`bootnode_addrs`](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L3169-L3174).",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-855",
+      "id": "chunk-857",
       "title": "Fiber Architecture & Module",
       "content": "Fiber supports three types of broadcast messages:\n\n- `NodeAnnouncement`\n- `ChannelAnnouncement`\n- `ChannelUpdate`\n\nThe raw broadcast data received is stored in the [storage module](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/store/store.rs#L482-L711), allowing messages to be efficiently indexed using a combination of `timestamp + message_id`. This enables quicker responses to query requests from peer nodes.\n\nWhen a node starts, the Graph module loads all stored messages using [load_from_store](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/graph.rs#L361) to rebuild its network graph.\n\nFiber propagates gossip messages using a subscription-based model.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-856",
+      "id": "chunk-858",
       "title": "Fiber Architecture & Module",
       "content": "1. A node actively sends a broadcast message filter (`BroadcastMessagesFilter`) to a peer.\n2. When the peer receives this filter, it creates a corresponding [PeerFilterActor](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/gossip.rs#L599-L614), which subscribes to gossip messages.\n\nThis subscription model allows nodes to efficiently receive newly stored gossip messages after a specific cursor, enabling them to dynamically update their network graph, because the network graph also subscribes to gossip messages. The logic for retrieving these messages is implemented in [this section](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/gossip.rs#L1027-L1049).",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-857",
+      "id": "chunk-859",
       "title": "Fiber Architecture & Module",
       "content": "### Enhancing Privacy with Onion Encryption & Decryption\n\nFor privacy and security consideration, payments’ TLC is propagated across multiple nodes using Onion encryption. Each node only accesses the minimal necessary details, such as:\n\n- The amount of the received TLC\n- The expiry of the TLC\n- The next node in the payment route\n\nThis approach ensures that a node cannot access other sensitive details, including the total length of the payment route. The payment sender encrypts the payment details using onion encryption, and each hop must obfuscate the information before forwarding the TLC to the next node.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-858",
+      "id": "chunk-860",
       "title": "Fiber Architecture & Module",
       "content": "In case of an error occurs at any hop during payment forwarding, the affected node sends back an error message along the reverse route to the sender. This error message is also onion-encrypted, ensuring that intermediate nodes cannot decipher its content—only the sender can decrypt it.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-859",
+      "id": "chunk-861",
       "title": "Fiber Architecture & Module",
       "content": "We examined the [onion packet implementation](https://github.com/lightningdevkit/rust-lightning/blob/master/lightning/src/ln/onion_utils.rs) in rust-lightning and found it to be tightly coupled with rust-lightning’s internal data structures, limiting its generalization. Therefore, we built [fiber-sphinx](https://github.com/cryptape/fiber-sphinx/blob/develop/docs/spec.md) from scratch. For more details, refer to the project spec and the [developer’s presentation slides](https://link.excalidraw.com/p/readonly/C6mOdLUnx0PkGWHwrnQs).\n\nThe key Onion Encryption & Decryption steps in Fiber include:",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-860",
+      "id": "chunk-862",
       "title": "Fiber Architecture & Module",
       "content": "- **Creating the Onion Packet for Sending Payments**\n    \n    Before sending a payment, the sender [creates an onion packet](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L1640-L1666), included in the `AddTlcCommand` sent to the first node in the payment route.\n    \n- **Onion Decryption at Each Hop**\n    - When a node in the payment route receives a TLC, it [decrypts one layer](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/channel.rs#L920-L937) of the onion packet, similar to peeling an onion.\n    - If the node is the final recipient, it processes the payment settlement logic.\n    - If the node is not the recipient, it continues processing the TLC and then [forwards the remaining onion packet](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/channel.rs#L1037-L1064) to the next hop.\n- **Generating an Onion Packet for Error Messages**\n    \n    If an error occurs during TLC forwarding, the node [creates a new onion packet containing the error message](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/channel.rs#L774-L797) and sends it back to the previous node.\n    \n- **Decrypting Error Messages at the Payment Sender**\n    \n    When the sender receives a TLC fail event, it [decrypts the onion packet containing the error](https://github.com/nervosnetwork/fiber/blob/e7bb8874e308445fdf63a5bc538fc00c100f3dc9/src/fiber/network.rs#L1518-L1527). Based on the error details, the sender can decide whether to resend and update the network graph accordingly.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-861",
+      "id": "chunk-863",
       "title": "Fiber Architecture & Module",
       "content": "![image](/imgs/docs/high-level/decrypt-receive.png)\n\n### Preventing Channels from Fraud via Watchtower\n\nWatchtower is an important security mechanism in the Lightning Network, primarily used to protect offline users from potential fund theft. It maintains fairness and security by real-time monitoring on-chain transactions and executing penalty transactions when violations are detected.\n\nFiber's watchtower implementation is in the [WatchtowerActor](https://github.com/nervosnetwork/fiber/blob/b5c38a800e94aaa368a4c8a8699f5db0c08ecfbd/src/watchtower/actor.rs#L73-L124). This actor listens for key events in the Fiber node. For example：",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-862",
+      "id": "chunk-864",
       "title": "Fiber Architecture & Module",
       "content": "- When a new channel is created, it receives a `RemoteTxComplete` event, while the watchtower inserts a corresponding record into the database to start monitoring this channel.\n- When the channel is closed through upon mutual agreement, it receives a `ChannelClosed` event, while the watchtower removes the corresponding record from the database.\n\nDuring **TLC interaction**s in the channel, the watchtower receives `RemoteCommitmentSigned` and `RevokeAndAckReceived` events, updating the `revocation_data` and `settlement_data` stored in the database respectively. These fields will be used later to create revocation and settlement transactions.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-863",
+      "id": "chunk-865",
       "title": "Fiber Architecture & Module",
       "content": "Watchtower's **penalty mechanism** ensures that old commitment transactions are not used in a on-chain transaction by [comparing the `commitment_number`](https://github.com/nervosnetwork/fiber/blob/b5c38a800e94aaa368a4c8a8699f5db0c08ecfbd/src/watchtower/actor.rs#L266). If a violation is detected, the watchtower constructs a **revocation transaction** and submits it on-chain to penalize the offender. Otherwise, it constructs and sends a **settlement transaction**.\n\n## **Other Technical Decisions**",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-864",
+      "id": "chunk-866",
       "title": "Fiber Architecture & Module",
       "content": "- **Storage**: We use RocksDB as the storage layer, leveraging its scheme-less storage design to simplify encoding and decoding structs with `serde`. Data migration remains a challenge, which we address by [this standalone program](https://github.com/nervosnetwork/fiber/blob/develop/migrate/src/main.rs).\n- **Serialization**: Messages between nodes are serialized and deserialized using [Molecule](https://github.com/nervosnetwork/molecule), bringing efficiency, compatibility, and security advantages. It ensures determinism, meaning the same message serializes identically on all nodes, which is crucial for signature generation and verification.\n\n## Future Prospects",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-865",
+      "id": "chunk-867",
       "title": "Fiber Architecture & Module",
       "content": "Fiber is still in the early stages of active development. Looking ahead, we plan to make further improvements in the following areas:\n\n- Fix unhandled corner cases to enhance overall robustness;\n- Improve the cross-chain hub (currently in the prototype verification stage) by introducing payment session functionality to make cross-chain transactions more user-friendly;\n- Refine the payment routing algorithm, potentially introducing multi-path feature and other path-finding strategies to accommodate diverse user preferences and needs;\n- Expand contract functionality, including version-based revocation mechanisms and more secure Point Time-Locked Contracts.",
       "url": "/docs/res/high-level",
       "source": "docs/res/high-level.mdx"
     },
     {
-      "id": "chunk-866",
+      "id": "chunk-868",
       "title": "Resources",
       "content": "# Resources\n\nThis section contains technical reference materials, protocol specifications, and additional resources for understanding Fiber Network at a deeper level.\n\n## Contents",
       "url": "/docs/res/index",
       "source": "docs/res/index.mdx"
     },
     {
-      "id": "chunk-867",
+      "id": "chunk-869",
       "title": "Resources",
       "content": "- [Glossary](/docs/res/glossary) — Key terms and definitions\n- [Network Resources](/docs/res/network-resources) — Public nodes, faucets, and testnet guides\n- [Light Paper](/docs/res/light-paper) — Overview of Fiber Network design\n- [High-Level Architecture](/docs/res/high-level) — System architecture and modules\n- [Payment Channel](/docs/res/payment-channel) — Payment channel theory\n- [Invoice Protocol](/docs/res/invoice-protocol) — Technical specification for invoices\n- [P2P Message Protocol](/docs/res/p2p-message) — Peer-to-peer communication protocol\n- [Cross-Chain HTLC](/docs/res/cross-chain-htlc) — Cross-chain atomic swaps",
       "url": "/docs/res/index",
       "source": "docs/res/index.mdx"
     },
     {
-      "id": "chunk-868",
+      "id": "chunk-870",
       "title": "Fiber Invoice Protocol",
       "content": "## Overall Design\n\nFiber network invoice will be generated and parsed by Fiber Node, we referred to the design of [BOLT 11](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md), and made some adjustments from an implementation perspective.\n\n- The invoice is encode/decoded base on [molecule](https://github.com/nervosnetwork/molecule), which is widely used in the CKB projects.\n- Instead of using `bech32`, we switch to `bech32m`.\n- The interface and usage is similar to [lightning-invoice](https://github.com/lightningdevkit/rust-lightning/tree/main/lightning-invoice/src) as possible, but not compatible with lightning invoice, any cross-chain compatibility needs will be handled through the hub in FNN.\n\n## Human-readable part",
       "url": "/docs/res/invoice-protocol",
       "source": "docs/res/invoice-protocol.mdx"
     },
     {
-      "id": "chunk-869",
-      "title": "Fiber Invoice Protocol",
-      "content": "The human-readable part contains these two most important fields:\n\n1. `prefix`: [mandatory] Specify the currency and network of payment\n    - `fibb` for the CKB mainnet,  `fibb` means `fiber bytes`, since in CKB ecosystem 1 CKB equals 1 Byte.\n    - `fibt` for the CKB testnet\n    - `fibd` for the CKB dev\n2. `amount`: [optional] An optional number in that currency.\n    - A standalone number, means the amount of CKB or UDT, for CKB it will be in unit of `shannon`, 1 CKB = 10^8 shannon\n    - An empty value for this field means the amount of payment is not specified, which maybe used in the scenario of donation.\n\n## Encoding and Decoding",
-      "url": "/docs/res/invoice-protocol",
-      "source": "docs/res/invoice-protocol.mdx"
-    },
-    {
-      "id": "chunk-870",
-      "title": "Fiber Invoice Protocol",
-      "content": "With `molecule`, the data part can be easily converted to bytes. Considering that the bytes generated by molecule are not optimized for space and may contain consecutive zeros when certain fields are empty, the result from `bechm32` encoding is relatively long. We use [arcode-rs](https://github.com/cgbur/arcode-rs) to compress the bytes losslessly before `bechm32` encoding, resulting in a length reduction of almost half:\n\n`data = compressed(data part molecule bytes) + signature`\n\n`encode(&hrp, data, Variant::Bech32m)`\n\nFor decoding, we simply perform the inverse decompression operation.\n\nThe `signature` field: [optional] with type of `[u8; 65]` = 520 bits",
-      "url": "/docs/res/invoice-protocol",
-      "source": "docs/res/invoice-protocol.mdx"
-    },
-    {
       "id": "chunk-871",
       "title": "Fiber Invoice Protocol",
-      "content": "- The secp256k1 signature of the entire invoice, can be used to verify the integrity and correctness of the invoice, may also be used to imply the generator node of this invoice.\nBy default, this filed is none, the method to generate signature:\n  - `message_hash = SHA256-hash (((human-readable part) → bytes) + (data bytes))`\n       then sign it with `Secp256k1`\n  - It may use a customized sign function: `Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key)`\n\n## Data Part\n\nThe data part is designed to add non-mandatory fields easily, and it is very likely that new field will be added in the future:",
+      "content": "The human-readable part contains these two most important fields:\n\n1. `prefix`: [mandatory] Specify the currency and network of payment\n    - `fibb` for the CKB mainnet,  `fibb` means `fiber bytes`, since in CKB ecosystem 1 CKB equals 1 Byte.\n    - `fibt` for the CKB testnet\n    - `fibd` for the CKB dev\n2. `amount`: [optional] An optional number in that currency.\n    - A standalone number, means the amount of CKB or UDT, for CKB it will be in unit of `shannon`, 1 CKB = 10^8 shannon\n    - An empty value for this field means the amount of payment is not specified, which maybe used in the scenario of donation.\n\n## Encoding and Decoding",
       "url": "/docs/res/invoice-protocol",
       "source": "docs/res/invoice-protocol.mdx"
     },
     {
       "id": "chunk-872",
       "title": "Fiber Invoice Protocol",
-      "content": "1. `timestamp`: [mandatory] 128 bits\n    - milliseconds since 1970\n    - The time the invoice was generated\n2. `payment_hash`: [mandatory] 256 bits\n    - SHA256 payment_hash, could specified when creating a invoice, but we need to make sure `payment_hash` is the unique identifier of a invoice.\n    - If creating a `HODL` invoice, a `preimage` parameter must be provided, and the `payment_hash` is generated using `blake2b_256(preimage)` when the invoice is created.\n    - For `AMP invoices` (Atomic Multi-path Payments), the `payment_hash` is randomly generated.\n3. `expiry`: [optional] 32 bits\n    - `timestamp + expiry` is the expiration time of the invoice\n    - Unit: seconds\n4. `description`: [optional] variable length\n    - A string of UTF-8 text to display payment information, such as \"a cup of coffee\"\n5. `final htlc timeout`: [optional] 32 bits\n    - Specifies the final htlc timeout, which may be longer because it may take more hops to reach CKB network\n    - Unit: seconds\n6. `fallback`: [optional] variable length\n    - A CKB address used for fallback in case the invoice payment fails\n7. `feature`: [optional] 32 bits\n    - Feature flag to specify features supported by the payment\n8. `payee_public_key`: [optional] 33 bytes\n    - The public key of the payee\n9. `udt_script`: [optional] variable length\n    - The script specified for the UDT token\n10. `hash_algorithm`: [optional] 1 byte\n    - The hash algorithm used to generate the `payment_hash` from the preimage. When this is missing, the default hash algorithm ckb hash is used.\n        - 0: ckb hash\n        - 1: sha256",
+      "content": "With `molecule`, the data part can be easily converted to bytes. Considering that the bytes generated by molecule are not optimized for space and may contain consecutive zeros when certain fields are empty, the result from `bechm32` encoding is relatively long. We use [arcode-rs](https://github.com/cgbur/arcode-rs) to compress the bytes losslessly before `bechm32` encoding, resulting in a length reduction of almost half:\n\n`data = compressed(data part molecule bytes) + signature`\n\n`encode(&hrp, data, Variant::Bech32m)`\n\nFor decoding, we simply perform the inverse decompression operation.\n\nThe `signature` field: [optional] with type of `[u8; 65]` = 520 bits",
       "url": "/docs/res/invoice-protocol",
       "source": "docs/res/invoice-protocol.mdx"
     },
     {
       "id": "chunk-873",
+      "title": "Fiber Invoice Protocol",
+      "content": "- The secp256k1 signature of the entire invoice, can be used to verify the integrity and correctness of the invoice, may also be used to imply the generator node of this invoice.\nBy default, this filed is none, the method to generate signature:\n  - `message_hash = SHA256-hash (((human-readable part) → bytes) + (data bytes))`\n       then sign it with `Secp256k1`\n  - It may use a customized sign function: `Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key)`\n\n## Data Part\n\nThe data part is designed to add non-mandatory fields easily, and it is very likely that new field will be added in the future:",
+      "url": "/docs/res/invoice-protocol",
+      "source": "docs/res/invoice-protocol.mdx"
+    },
+    {
+      "id": "chunk-874",
+      "title": "Fiber Invoice Protocol",
+      "content": "1. `timestamp`: [mandatory] 128 bits\n    - milliseconds since 1970\n    - The time the invoice was generated\n2. `payment_hash`: [mandatory] 256 bits\n    - SHA256 payment_hash, could specified when creating a invoice, but we need to make sure `payment_hash` is the unique identifier of a invoice.\n    - If creating a `HODL` invoice, a `preimage` parameter must be provided, and the `payment_hash` is generated using `blake2b_256(preimage)` when the invoice is created.\n    - For `AMP invoices` (Atomic Multi-path Payments), the `payment_hash` is randomly generated.\n3. `expiry`: [optional] 32 bits\n    - `timestamp + expiry` is the expiration time of the invoice\n    - Unit: seconds\n4. `description`: [optional] variable length\n    - A string of UTF-8 text to display payment information, such as \"a cup of coffee\"\n5. `final htlc timeout`: [optional] 32 bits\n    - Specifies the final htlc timeout, which may be longer because it may take more hops to reach CKB network\n    - Unit: seconds\n6. `fallback`: [optional] variable length\n    - A CKB address used for fallback in case the invoice payment fails\n7. `feature`: [optional] 32 bits\n    - Feature flag to specify features supported by the payment\n8. `payee_public_key`: [optional] 33 bytes\n    - The public key of the payee\n9. `udt_script`: [optional] variable length\n    - The script specified for the UDT token\n10. `hash_algorithm`: [optional] 1 byte\n    - The hash algorithm used to generate the `payment_hash` from the preimage. When this is missing, the default hash algorithm ckb hash is used.\n        - 0: ckb hash\n        - 1: sha256",
+      "url": "/docs/res/invoice-protocol",
+      "source": "docs/res/invoice-protocol.mdx"
+    },
+    {
+      "id": "chunk-875",
       "title": "Fiber Network Light Paper",
       "content": "## Overview\n\nFiber Network is a next-generation, common lightning network built on Nervos CKB and off-chain channels. It is designed to provide fast, low-cost, and decentralized multi-token payments and peer-to-peer transactions for RGB++ assets.\n\n## Background\n\n### Evolution and Challenges of Blockchain Technology\n\nBlockchain technology has undergone rapid evolution since the inception of Bitcoin. Initially designed for simple payments, it has gradually expanded into various domains such as smart contracts, decentralized finance (DeFi), and non-fungible tokens (NFTs). Despite its significant advantages in security, transparency, and decentralization, blockchain technology faces several challenges in scalability and transaction speed.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
-      "id": "chunk-874",
-      "title": "Fiber Network Light Paper",
-      "content": "1. Scalability. Traditional blockchains like Bitcoin and Ethereum face significant bottlenecks in transaction throughput. Due to Bitcoin's block size limit and 10-minute block generation time, its network can only process about 7 transactions per second; Ethereum, despite improvements, still has a transaction processing capacity far below traditional payment networks.\n\n2. High transaction fees. As network congestion increases, transaction fees rise significantly. For instance, gas fees on the Ethereum network during peak times may exceed the transaction amount itself, severely affecting user experience and reducing the feasibility of micropayments.",
-      "url": "/docs/res/light-paper",
-      "source": "docs/res/light-paper.mdx"
-    },
-    {
-      "id": "chunk-875",
-      "title": "Fiber Network Light Paper",
-      "content": "3. Long transaction confirmation times. In traditional blockchain networks, transactions need to wait for multiple block confirmations to be considered final. This process can take minutes to hours, making it unsuitable for instant payment scenarios.\n\nAlthough Nervos CKB has made improvements in terms of performance and confirmation times, it still needs to further increase transaction speed and reduce transaction costs to meet the demands of micropayments and instant payments.\n\n### Inspiration from the Lightning Network\n\nThe Lightning Network, a layer 2 scaling solution for the Bitcoin network, has successfully achieved fast, low-cost micropayments through off-chain transactions and payment channels. Its core concepts include:",
-      "url": "/docs/res/light-paper",
-      "source": "docs/res/light-paper.mdx"
-    },
-    {
       "id": "chunk-876",
       "title": "Fiber Network Light Paper",
-      "content": "1. Payment channels: Users create payment channels on-chain. Once a channel is opened, both parties can conduct unlimited off-chain transactions, only settling on-chain when the channel is closed. This significantly reduces the number of on-chain transactions, improves transaction speed, and lowers transaction fees.\n\n2. Hash Time-Locked Contracts (HTLC): Through HTLCs, the Lightning Network ensures secure fund transfers, mitigating counterparty risk. Even if off-chain transactions fail, users can still secure their funds through on-chain contracts.\n\n3. Routing mechanism: The Lightning Network uses multi-hop routing, allowing users to complete payments without opening direct channels with recipients, thus enhancing network flexibility and usability.\n\n## Advantages of Nervos CKB",
+      "content": "1. Scalability. Traditional blockchains like Bitcoin and Ethereum face significant bottlenecks in transaction throughput. Due to Bitcoin's block size limit and 10-minute block generation time, its network can only process about 7 transactions per second; Ethereum, despite improvements, still has a transaction processing capacity far below traditional payment networks.\n\n2. High transaction fees. As network congestion increases, transaction fees rise significantly. For instance, gas fees on the Ethereum network during peak times may exceed the transaction amount itself, severely affecting user experience and reducing the feasibility of micropayments.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-877",
       "title": "Fiber Network Light Paper",
-      "content": "Nervos CKB is a blockchain platform focused on versatility and security. Its unique design offers distinct advantages in addressing blockchain scalability and interoperability issues:\n\n1. Consensus mechanism: Based on the [NC-Max](https://eprint.iacr.org/2020/1101) consensus protocol, it combines Proof of Work (PoW) with state rent mechanisms, ensuring network security and effective resource utilization.",
+      "content": "3. Long transaction confirmation times. In traditional blockchain networks, transactions need to wait for multiple block confirmations to be considered final. This process can take minutes to hours, making it unsuitable for instant payment scenarios.\n\nAlthough Nervos CKB has made improvements in terms of performance and confirmation times, it still needs to further increase transaction speed and reduce transaction costs to meet the demands of micropayments and instant payments.\n\n### Inspiration from the Lightning Network\n\nThe Lightning Network, a layer 2 scaling solution for the Bitcoin network, has successfully achieved fast, low-cost micropayments through off-chain transactions and payment channels. Its core concepts include:",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-878",
       "title": "Fiber Network Light Paper",
-      "content": "2. Powerful smart contract capabilities: CKB's unique Cell model and RISC-V instruction set virtual machine significantly enhance the capabilities of the UTXO model. This not only supports Turing-complete smart contracts but also easily implements features such as account abstraction and covenants, providing more flexible programmability, better interoperability, and scalability for decentralized applications.\n\n3. Tokenomics: CKB's tokenomics encourages long-term holding and rational use of network resources, providing a secure and sustainable decentralized environment for applications, developers, and users.\n\n## Significance of the Fiber Network Project",
+      "content": "1. Payment channels: Users create payment channels on-chain. Once a channel is opened, both parties can conduct unlimited off-chain transactions, only settling on-chain when the channel is closed. This significantly reduces the number of on-chain transactions, improves transaction speed, and lowers transaction fees.\n\n2. Hash Time-Locked Contracts (HTLC): Through HTLCs, the Lightning Network ensures secure fund transfers, mitigating counterparty risk. Even if off-chain transactions fail, users can still secure their funds through on-chain contracts.\n\n3. Routing mechanism: The Lightning Network uses multi-hop routing, allowing users to complete payments without opening direct channels with recipients, thus enhancing network flexibility and usability.\n\n## Advantages of Nervos CKB",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-879",
       "title": "Fiber Network Light Paper",
-      "content": "By building off-chain channels on Nervos CKB, we aim to combine the successful experience of the Lightning Network with CKB's technical advantages to create a fast, low-cost, and decentralized multi-asset real-time payment network. Specifically:\n\n1. Solving scalability issues: Through off-chain payment channels and multi-hop routing, Fiber Network can achieve high-throughput transaction processing, meeting the needs of large-scale users.\n\n2. Reducing transaction costs: By reducing the frequency of on-chain transactions, it lowers transaction fees, making micropayments feasible and efficient.\n\n3. Improving transaction speed: The instant confirmation of off-chain transactions provides a split second payment confirmation experience suitable for various instant payment scenarios.",
+      "content": "Nervos CKB is a blockchain platform focused on versatility and security. Its unique design offers distinct advantages in addressing blockchain scalability and interoperability issues:\n\n1. Consensus mechanism: Based on the [NC-Max](https://eprint.iacr.org/2020/1101) consensus protocol, it combines Proof of Work (PoW) with state rent mechanisms, ensuring network security and effective resource utilization.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-880",
       "title": "Fiber Network Light Paper",
-      "content": "4. Multi-asset support: Fiber Network supports payments in a variety of digital assets, offering users a broader range of payment options.\n\n5. Interoperability: Fiber Network supports interoperability with the Bitcoin Lightning Network, providing support for cross-chain payments and asset transfers.\n\n## Architecture Design\n\n### Overall Architecture\n\nThe overall architecture of Fiber Network includes the following core modules:\n\n1. Off-Chain Payment Channels (Fiber Channels)\n\n2. On-Chain Contracts (HTLC)\n\n3. Multi-Hop Routing\n\n4. Watchtower Service\n\n### Off-chain Payment Channels",
+      "content": "2. Powerful smart contract capabilities: CKB's unique Cell model and RISC-V instruction set virtual machine significantly enhance the capabilities of the UTXO model. This not only supports Turing-complete smart contracts but also easily implements features such as account abstraction and covenants, providing more flexible programmability, better interoperability, and scalability for decentralized applications.\n\n3. Tokenomics: CKB's tokenomics encourages long-term holding and rational use of network resources, providing a secure and sustainable decentralized environment for applications, developers, and users.\n\n## Significance of the Fiber Network Project",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-881",
       "title": "Fiber Network Light Paper",
-      "content": "Off-chain payment channels are the core of Fiber Network, enabling multiple off-chain transactions with on-chain settlement only when the channel is closed. This mechanism significantly reduces the number of on-chain transactions, improves transaction speed, and lowers transaction fees.\nThe general workflow is as follows:\n\n1. Opening a Channel: Two parties open a payment channel on-chain, locking a certain amount of CKB or RGB++ assets.\n\n2. Off-chain transactions: When the channel is open, both parties can conduct an unlimited number of off-chain transactions, updating the channel state with each transaction without immediate broadcasting to the chain.",
+      "content": "By building off-chain channels on Nervos CKB, we aim to combine the successful experience of the Lightning Network with CKB's technical advantages to create a fast, low-cost, and decentralized multi-asset real-time payment network. Specifically:\n\n1. Solving scalability issues: Through off-chain payment channels and multi-hop routing, Fiber Network can achieve high-throughput transaction processing, meeting the needs of large-scale users.\n\n2. Reducing transaction costs: By reducing the frequency of on-chain transactions, it lowers transaction fees, making micropayments feasible and efficient.\n\n3. Improving transaction speed: The instant confirmation of off-chain transactions provides a split second payment confirmation experience suitable for various instant payment scenarios.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-882",
       "title": "Fiber Network Light Paper",
-      "content": "3. Closing the Channel: When either party decides to close the channel, the final channel state is broadcasted on-chain for settlement, ensuring the final balances of both parties are confirmed.\n\nThe message interaction format can be referenced in the [Fiber Network P2P Message Protocol](./specs/p2p-message.md).\n\n### On-Chain Contracts\n\nCurrently, we use Hash Time-Locked Contracts (HTLC) to ensure the security of off-chain transactions and maintain compatibility with the Lightning Network. This mitigates counterparty risk, ensuring that even if off-chain transactions fail, users can still secure their funds through on-chain contracts.\n\nThe general workflow is as follows:",
+      "content": "4. Multi-asset support: Fiber Network supports payments in a variety of digital assets, offering users a broader range of payment options.\n\n5. Interoperability: Fiber Network supports interoperability with the Bitcoin Lightning Network, providing support for cross-chain payments and asset transfers.\n\n## Architecture Design\n\n### Overall Architecture\n\nThe overall architecture of Fiber Network includes the following core modules:\n\n1. Off-Chain Payment Channels (Fiber Channels)\n\n2. On-Chain Contracts (HTLC)\n\n3. Multi-Hop Routing\n\n4. Watchtower Service\n\n### Off-chain Payment Channels",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-883",
       "title": "Fiber Network Light Paper",
-      "content": "1. Transaction initiation: The payment initiator creates a transaction with hashlock and timelock, and locks a certain amount of CKB.\n\n2. Hash verification: The payment recipient must provide the correct hash preimage within the specified time to unlock the transaction and complete the fund transfer.\n\n3. Timeout refund: If the recipient fails to provide the correct hash preimage within the specified time, the transaction will automatically unlock and refund to the payment initiator.\n\nThanks to CKB's Turing completeness, we can implement more flexible and secure on-chain contracts. We will further expand the contract's functionality in the future, such as introducing a version-based revocation mechanism and more secure Point Time-Locked Contracts.\n\n### Multi-hop Routing",
+      "content": "Off-chain payment channels are the core of Fiber Network, enabling multiple off-chain transactions with on-chain settlement only when the channel is closed. This mechanism significantly reduces the number of on-chain transactions, improves transaction speed, and lowers transaction fees.\nThe general workflow is as follows:\n\n1. Opening a Channel: Two parties open a payment channel on-chain, locking a certain amount of CKB or RGB++ assets.\n\n2. Off-chain transactions: When the channel is open, both parties can conduct an unlimited number of off-chain transactions, updating the channel state with each transaction without immediate broadcasting to the chain.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-884",
       "title": "Fiber Network Light Paper",
-      "content": "Multi-hop routing allows users to complete payments through multiple intermediate nodes without establishing direct payment channels with the counterparty. This mechanism enhances the network's flexibility and coverage.\n\nThe general workflow is as follows:\n\n1. Path discovery: The payment initiator discovers the optimal path from themselves to the payment recipient through the routing module.\n\n2. Path locking: Each node on the path creates corresponding HTLC contracts, ensuring secure fund transfers.\n\n3. Payment completion: The payment recipient unlocks the HTLC, and funds are transferred sequentially to each node on the path.",
+      "content": "3. Closing the Channel: When either party decides to close the channel, the final channel state is broadcasted on-chain for settlement, ensuring the final balances of both parties are confirmed.\n\nThe message interaction format can be referenced in the [Fiber Network P2P Message Protocol](./specs/p2p-message.md).\n\n### On-Chain Contracts\n\nCurrently, we use Hash Time-Locked Contracts (HTLC) to ensure the security of off-chain transactions and maintain compatibility with the Lightning Network. This mitigates counterparty risk, ensuring that even if off-chain transactions fail, users can still secure their funds through on-chain contracts.\n\nThe general workflow is as follows:",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-885",
       "title": "Fiber Network Light Paper",
-      "content": "We will also implement cross-chain payments here using HTLC contracts, supporting interoperability with the Lightning Network through the cross-chain hub service. For more details, please refer to [Payment Channel Cross-Chain Protocol with HTLC](./specs/cross-chain-htlc.md).\n\n### Watchtower Service\n\nThe watchtower service is an essential component of Fiber Network, responsible for monitoring the state of off-chain payment channels and ensuring the security of channels and funds. Its functions and roles are as follows:\n\n1. Channel monitoring: Real-time monitoring of the payment channel state of all participating users, including opening, updating, and closing channels.",
+      "content": "1. Transaction initiation: The payment initiator creates a transaction with hashlock and timelock, and locks a certain amount of CKB.\n\n2. Hash verification: The payment recipient must provide the correct hash preimage within the specified time to unlock the transaction and complete the fund transfer.\n\n3. Timeout refund: If the recipient fails to provide the correct hash preimage within the specified time, the transaction will automatically unlock and refund to the payment initiator.\n\nThanks to CKB's Turing completeness, we can implement more flexible and secure on-chain contracts. We will further expand the contract's functionality in the future, such as introducing a version-based revocation mechanism and more secure Point Time-Locked Contracts.\n\n### Multi-hop Routing",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-886",
       "title": "Fiber Network Light Paper",
-      "content": "2. Anomaly detection: Detecting abnormal activities in channels, such as malicious users attempting to close channels with old states or double-spending attacks.\n\n3. Proactive response: When anomalies are detected, promptly broadcasting the latest channel state to the blockchain network to prevent fund losses due to malicious behavior.\n\n## Current Progress and Future Plans\n\nWe have currently completed a prototype of Fiber Network, implementing basic functions of opening, updating, and closing channels between two nodes, and also verifying cross-chain functionality with the Bitcoin Lightning Network. The project code can be found in the following GitHub repositories:\n\n1. https://github.com/nervosnetwork/fiber\n\n2. https://github.com/nervosnetwork/fiber-scripts",
+      "content": "Multi-hop routing allows users to complete payments through multiple intermediate nodes without establishing direct payment channels with the counterparty. This mechanism enhances the network's flexibility and coverage.\n\nThe general workflow is as follows:\n\n1. Path discovery: The payment initiator discovers the optimal path from themselves to the payment recipient through the routing module.\n\n2. Path locking: Each node on the path creates corresponding HTLC contracts, ensuring secure fund transfers.\n\n3. Payment completion: The payment recipient unlocks the HTLC, and funds are transferred sequentially to each node on the path.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-887",
       "title": "Fiber Network Light Paper",
-      "content": "Our next steps include completing multi-hop routing and watchtower services, as well as improving the RPC interface and SDK to facilitate easier access for developers to Fiber Network.",
+      "content": "We will also implement cross-chain payments here using HTLC contracts, supporting interoperability with the Lightning Network through the cross-chain hub service. For more details, please refer to [Payment Channel Cross-Chain Protocol with HTLC](./specs/cross-chain-htlc.md).\n\n### Watchtower Service\n\nThe watchtower service is an essential component of Fiber Network, responsible for monitoring the state of off-chain payment channels and ensuring the security of channels and funds. Its functions and roles are as follows:\n\n1. Channel monitoring: Real-time monitoring of the payment channel state of all participating users, including opening, updating, and closing channels.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-888",
       "title": "Fiber Network Light Paper",
-      "content": "The multi-hop routing protocol is based on the Dijkstra algorithm to search for payment paths, thereby reducing routing fees and improving the success rate of multi-hop path payments. After Fiber Network goes live, we will optimize the routing algorithm based on network traffic and operational conditions. We expect to provide 2 or 3 path search strategies to adapt to users' different routing preferences and needs. Fiber Network will also introduce multi-path payment strategies, dividing larger payment amounts into multiple parts, each transmitted through different paths, further increasing the probability of successful payments.",
+      "content": "2. Anomaly detection: Detecting abnormal activities in channels, such as malicious users attempting to close channels with old states or double-spending attacks.\n\n3. Proactive response: When anomalies are detected, promptly broadcasting the latest channel state to the blockchain network to prevent fund losses due to malicious behavior.\n\n## Current Progress and Future Plans\n\nWe have currently completed a prototype of Fiber Network, implementing basic functions of opening, updating, and closing channels between two nodes, and also verifying cross-chain functionality with the Bitcoin Lightning Network. The project code can be found in the following GitHub repositories:\n\n1. https://github.com/nervosnetwork/fiber\n\n2. https://github.com/nervosnetwork/fiber-scripts",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-889",
       "title": "Fiber Network Light Paper",
-      "content": "The watchtower service will be provided by some nodes in Fiber Network. These nodes will stay online, monitor abnormal situations in the network, and help protect assets in channels. The monitoring service will also track the cross-chain hub service. Even if users are offline for a period, the monitoring service can ensure successful exchanges with the Lightning Network.\n\nAdditionally, we will consider adding more features to Fiber Network, such as implementing privacy protection algorithms leveraging CKB's programmability, and based on this, optimizing routing algorithms and watchtower services to enhance the security and privacy of users’ payment information.",
+      "content": "Our next steps include completing multi-hop routing and watchtower services, as well as improving the RPC interface and SDK to facilitate easier access for developers to Fiber Network.",
       "url": "/docs/res/light-paper",
       "source": "docs/res/light-paper.mdx"
     },
     {
       "id": "chunk-890",
+      "title": "Fiber Network Light Paper",
+      "content": "The multi-hop routing protocol is based on the Dijkstra algorithm to search for payment paths, thereby reducing routing fees and improving the success rate of multi-hop path payments. After Fiber Network goes live, we will optimize the routing algorithm based on network traffic and operational conditions. We expect to provide 2 or 3 path search strategies to adapt to users' different routing preferences and needs. Fiber Network will also introduce multi-path payment strategies, dividing larger payment amounts into multiple parts, each transmitted through different paths, further increasing the probability of successful payments.",
+      "url": "/docs/res/light-paper",
+      "source": "docs/res/light-paper.mdx"
+    },
+    {
+      "id": "chunk-891",
+      "title": "Fiber Network Light Paper",
+      "content": "The watchtower service will be provided by some nodes in Fiber Network. These nodes will stay online, monitor abnormal situations in the network, and help protect assets in channels. The monitoring service will also track the cross-chain hub service. Even if users are offline for a period, the monitoring service can ensure successful exchanges with the Lightning Network.\n\nAdditionally, we will consider adding more features to Fiber Network, such as implementing privacy protection algorithms leveraging CKB's programmability, and based on this, optimizing routing algorithms and watchtower services to enhance the security and privacy of users’ payment information.",
+      "url": "/docs/res/light-paper",
+      "source": "docs/res/light-paper.mdx"
+    },
+    {
+      "id": "chunk-892",
       "title": "Fiber P2P Message Protocol",
       "content": "This document describes the protocol between nodes of the fiber network on CKB, used to establish payment channels, construct transactions, close channels, and perform payment operations. Essentially, it is an adaptation and simplification of [BOLT 02] to suit the transaction structure of CKB.\n\nPlease note that BOLT 02 uses HTLC (Hashed Time Locked Contract) for payment operations, and many message definitions use HTLC as field names and descriptions. In this document, we will use TLC instead of HTLC to facilitate future support for PTLC (Point Time Locked Contract). Additionally, this protocol will use [Molecule] to define message formats, making it easier to integrate with CKB.\n\n***This document is a work in progress and may be updated at any time.***\n\n## Channel Establishment",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
-      "id": "chunk-891",
+      "id": "chunk-893",
       "title": "Fiber P2P Message Protocol",
       "content": "We use a protocol similar to BOLTS 02 Channel Establishment v2 to establish payment channels, an example process is as follows:",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
-      "id": "chunk-892",
-      "title": "Fiber P2P Message Protocol",
-      "content": "```\n    +-------+                              +-------+\n    |       |--(1)--- OpenChannel     ---->|       |\n    |       |<-(2)--- AcceptChannel   -----|       |\n    |       |                              |       |\n--->|       |      <tx collaboration>      |       |\n|   |       |                              |       |\n|   |       |--(3)--  commitment_signed -->|       |\n|   |       |<-(4)--  commitment_signed ---|       |\n|   |   A   |                              |   B   |\n|   |       |<-(5)--  tx_signatures -------|       |\n|   |       |--(6)--  tx_signatures ------>|       |\n|   |       |                              |       |\n|   |       |--(a)--- tx_init_rbf -------->|       |\n----|       |<-(b)--- tx_ack_rbf ----------|       |\n    |       |                              |       |\n    |       |    <tx rbf collaboration>    |       |\n    |       |                              |       |\n    |       |--(c)--  commitment_signed -->|       |\n    |       |<-(d)--  commitment_signed ---|       |\n    |       |                              |       |\n    |       |<-(e)--  tx_signatures -------|       |\n    |       |--(f)--  tx_signatures ------>|       |\n    |       |                              |       |\n    |       |--(7)--- channel_ready  ----->|       |\n    |       |<-(8)--- channel_ready  ------|       |\n    +-------+                              +-------+",
-      "url": "/docs/res/p2p-message",
-      "source": "docs/res/p2p-message.mdx"
-    },
-    {
-      "id": "chunk-893",
-      "title": "Fiber P2P Message Protocol",
-      "content": "- where node A is *opener*/*initiator* and node B is\n      *accepter*/*non-initiator*\n```\n### OpenChannel\n\n`OpenChannel` is sent by the initiator of the channel to the receiver of the channel to request the establishment of a payment channel.",
-      "url": "/docs/res/p2p-message",
-      "source": "docs/res/p2p-message.mdx"
-    },
-    {
       "id": "chunk-894",
       "title": "Fiber P2P Message Protocol",
-      "content": "```\ntable OpenChannel {\n    chain_hash:                  Byte32,\n    channel_id:                  Byte32,\n    funding_type_script:         ScriptOpt,\n    funding_amount:              Uint128,\n    funding_fee_rate:            Uint64,\n    commitment_fee_rate:         Uint64,\n    max_tlc_value_in_flight:     Uint128,\n    max_tlc_number_in_flight:    Uint64,\n    min_tlc_value:               Uint128,\n    to_self_delay:               Uint64,\n    funding_pubkey:              Byte33,\n    tlc_basepoint:               Byte33,\n    first_per_commitment_point:  Byte33,\n    second_per_commitment_point: Byte33,\n    next_local_nonce:            Byte66,\n    channel_flags:               Byte,\n}\n```",
+      "content": "```\n    +-------+                              +-------+\n    |       |--(1)--- OpenChannel     ---->|       |\n    |       |<-(2)--- AcceptChannel   -----|       |\n    |       |                              |       |\n--->|       |      <tx collaboration>      |       |\n|   |       |                              |       |\n|   |       |--(3)--  commitment_signed -->|       |\n|   |       |<-(4)--  commitment_signed ---|       |\n|   |   A   |                              |   B   |\n|   |       |<-(5)--  tx_signatures -------|       |\n|   |       |--(6)--  tx_signatures ------>|       |\n|   |       |                              |       |\n|   |       |--(a)--- tx_init_rbf -------->|       |\n----|       |<-(b)--- tx_ack_rbf ----------|       |\n    |       |                              |       |\n    |       |    <tx rbf collaboration>    |       |\n    |       |                              |       |\n    |       |--(c)--  commitment_signed -->|       |\n    |       |<-(d)--  commitment_signed ---|       |\n    |       |                              |       |\n    |       |<-(e)--  tx_signatures -------|       |\n    |       |--(f)--  tx_signatures ------>|       |\n    |       |                              |       |\n    |       |--(7)--- channel_ready  ----->|       |\n    |       |<-(8)--- channel_ready  ------|       |\n    +-------+                              +-------+",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-895",
       "title": "Fiber P2P Message Protocol",
-      "content": "- chain_hash: Chain genesis block hash\n- channel_id: The ID of the channel, which is a temporary ID derived from the tlc_basepoint before the channel is officially established. After the channel is established, it will be replaced with the actual channel ID, derived from a blake2b hash of the sorted tlc_basepoints of both parties.\n- funding_type_script: Specifies the asset type of the channel. If empty, it indicates using CKB native token as the asset.\n- funding_amount: The amount of assets the channel initiator wants to contribute.\n- funding_fee_rate: Funding transaction fee rate, in shannons per kilo-bytes.\n- commitment_fee_rate: Commitment transaction fee rate, in shannons per kilo-bytes.\n- max_tlc_value_in_flight: The maximum total value of unconfirmed TLCs (Time Locked Contracts) that the channel initiator can accept in this channel.\n- max_tlc_number_in_flight: The maximum number of unconfirmed TLCs that the channel initiator can accept in this channel.\n- min_tlc_value: The minimum value of TLCs that the channel initiator can accept.\n- to_self_delay: The delay time for the channel initiator to unlock the outputs from the commitment transaction, in EpochNumberWithFraction.\n- funding_pubkey: The pubkey of the channel initiator, used for generating 2-2 multisig contracts.\n- tlc_basepoint: The master key used to derive child keys required for tlcs, we will use the same method as lightning network to derive these keys, see [Secret Derivations] for more details.\n- first_per_commitment_point:\n- second_per_commitment_point:\n- next_local_nonce: Used for generating partial signatures for unlocking 2-2 Schnorr multisig.\n- channel_flags: Channel flags, currently only using one bit to indicate whether to broadcast this channel information on the P2P network.",
+      "content": "- where node A is *opener*/*initiator* and node B is\n      *accepter*/*non-initiator*\n```\n### OpenChannel\n\n`OpenChannel` is sent by the initiator of the channel to the receiver of the channel to request the establishment of a payment channel.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-896",
       "title": "Fiber P2P Message Protocol",
-      "content": "### AcceptChannel\n\n`AcceptChannel` is sent by the receiver of the channel to the initiator of the channel to accept the establishment of a payment channel.\n\n```\ntable AcceptChannel {\n    channel_id:                  Byte32,\n    funding_amount:              Uint128,\n    max_tlc_value_in_flight:     Uint128,\n    max_tlc_number_in_flight:    Uint64,\n    min_tlc_value:               Uint128,\n    to_self_delay:               Uint64,\n    funding_pubkey:              Byte33,\n    tlc_basepoint:               Byte33,\n    payment_basepoint:           Byte33,\n    delayed_payment_basepoint:   Byte33,\n    first_per_commitment_point:  Byte33,\n    second_per_commitment_point: Byte33,\n    next_local_nonce:            Byte66,\n}\n```",
+      "content": "```\ntable OpenChannel {\n    chain_hash:                  Byte32,\n    channel_id:                  Byte32,\n    funding_type_script:         ScriptOpt,\n    funding_amount:              Uint128,\n    funding_fee_rate:            Uint64,\n    commitment_fee_rate:         Uint64,\n    max_tlc_value_in_flight:     Uint128,\n    max_tlc_number_in_flight:    Uint64,\n    min_tlc_value:               Uint128,\n    to_self_delay:               Uint64,\n    funding_pubkey:              Byte33,\n    tlc_basepoint:               Byte33,\n    first_per_commitment_point:  Byte33,\n    second_per_commitment_point: Byte33,\n    next_local_nonce:            Byte66,\n    channel_flags:               Byte,\n}\n```",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-897",
       "title": "Fiber P2P Message Protocol",
-      "content": "- channel_id: The ID of the channel, must match the channel_id in OpenChannel.\n- funding_amount: The amount of assets the channel receiver wants to contribute, can be 0, indicating no contribution.\n- max_tlc_value_in_flight: The maximum total value of unconfirmed TLCs that the channel receiver can accept in this channel.\n- max_tlc_number_in_flight: The maximum number of unconfirmed TLCs that the channel receiver can accept in this channel.\n- min_tlc_value: The minimum value of TLCs that the channel receiver can accept.\n- to_self_delay: The delay time for the channel receiver to unlock the outputs from the commitment transaction, in EpochNumberWithFraction.\n- funding_pubkey: The pubkey of the channel receiver, used for generating 2-2 multisig contracts.\n- tlc_basepoint: See the description in `OpenChannel` message.\n- first_per_commitment_point:\n- second_per_commitment_point:\n- next_local_nonce: Used for generating partial signatures for unlocking 2-2 Schnorr multisig.",
+      "content": "- chain_hash: Chain genesis block hash\n- channel_id: The ID of the channel, which is a temporary ID derived from the tlc_basepoint before the channel is officially established. After the channel is established, it will be replaced with the actual channel ID, derived from a blake2b hash of the sorted tlc_basepoints of both parties.\n- funding_type_script: Specifies the asset type of the channel. If empty, it indicates using CKB native token as the asset.\n- funding_amount: The amount of assets the channel initiator wants to contribute.\n- funding_fee_rate: Funding transaction fee rate, in shannons per kilo-bytes.\n- commitment_fee_rate: Commitment transaction fee rate, in shannons per kilo-bytes.\n- max_tlc_value_in_flight: The maximum total value of unconfirmed TLCs (Time Locked Contracts) that the channel initiator can accept in this channel.\n- max_tlc_number_in_flight: The maximum number of unconfirmed TLCs that the channel initiator can accept in this channel.\n- min_tlc_value: The minimum value of TLCs that the channel initiator can accept.\n- to_self_delay: The delay time for the channel initiator to unlock the outputs from the commitment transaction, in EpochNumberWithFraction.\n- funding_pubkey: The pubkey of the channel initiator, used for generating 2-2 multisig contracts.\n- tlc_basepoint: The master key used to derive child keys required for tlcs, we will use the same method as lightning network to derive these keys, see [Secret Derivations] for more details.\n- first_per_commitment_point:\n- second_per_commitment_point:\n- next_local_nonce: Used for generating partial signatures for unlocking 2-2 Schnorr multisig.\n- channel_flags: Channel flags, currently only using one bit to indicate whether to broadcast this channel information on the P2P network.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-898",
       "title": "Fiber P2P Message Protocol",
-      "content": "### CommitmentSigned\n\nAfter both parties establish the funding transaction and complete the signing of the commitment transaction in the [Transaction Collaboration](#Transaction-Collaboration) process, they will send CommitmentSigned messages to each other.\n\n```\ntable CommitmentSigned {\n    channel_id:        Byte32,\n\tpartial_signature: Byte32,\n    next_local_nonce:  Byte66,\n}\n```\n\nThe meaning of each field is as follows:\n\n- partial_signature: The partial signature for unlocking the 2-2 Schnorr multisig.\n- next_local_nonce: Used for generating the next commitment transaction partial signature.\n\n### TxSignatures",
+      "content": "### AcceptChannel\n\n`AcceptChannel` is sent by the receiver of the channel to the initiator of the channel to accept the establishment of a payment channel.\n\n```\ntable AcceptChannel {\n    channel_id:                  Byte32,\n    funding_amount:              Uint128,\n    max_tlc_value_in_flight:     Uint128,\n    max_tlc_number_in_flight:    Uint64,\n    min_tlc_value:               Uint128,\n    to_self_delay:               Uint64,\n    funding_pubkey:              Byte33,\n    tlc_basepoint:               Byte33,\n    payment_basepoint:           Byte33,\n    delayed_payment_basepoint:   Byte33,\n    first_per_commitment_point:  Byte33,\n    second_per_commitment_point: Byte33,\n    next_local_nonce:            Byte66,\n}\n```",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-899",
       "title": "Fiber P2P Message Protocol",
-      "content": "After both parties have signed the commitment transaction and verified the correctness of each other's signatures, they need to send TxSignatures messages to each other to complete the signing of the funding transaction.\n\n```\ntable TxSignatures {\n    channel_id: Byte32,\n    tx_hash:    Byte32,\n    witnesses:  BytesVec,\n}\n```\n\nHere, tx_hash is the hash of the corresponding funding transaction, and witnesses corresponds to the signed witnesses of all inputs of the contributor. If a party's contribution is 0 (i.e., no inputs), an empty witnesses message should also be sent to complete the message exchange.",
+      "content": "- channel_id: The ID of the channel, must match the channel_id in OpenChannel.\n- funding_amount: The amount of assets the channel receiver wants to contribute, can be 0, indicating no contribution.\n- max_tlc_value_in_flight: The maximum total value of unconfirmed TLCs that the channel receiver can accept in this channel.\n- max_tlc_number_in_flight: The maximum number of unconfirmed TLCs that the channel receiver can accept in this channel.\n- min_tlc_value: The minimum value of TLCs that the channel receiver can accept.\n- to_self_delay: The delay time for the channel receiver to unlock the outputs from the commitment transaction, in EpochNumberWithFraction.\n- funding_pubkey: The pubkey of the channel receiver, used for generating 2-2 multisig contracts.\n- tlc_basepoint: See the description in `OpenChannel` message.\n- first_per_commitment_point:\n- second_per_commitment_point:\n- next_local_nonce: Used for generating partial signatures for unlocking 2-2 Schnorr multisig.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-900",
       "title": "Fiber P2P Message Protocol",
-      "content": "In addition, in order to simplify the message interaction process, we defined that the party with the lesser amount of funding must send the\nTxSignatures message first, in the case of the same amount, the one with the smaller funding_pubkey must send the TxSignatures message first. This avoids deadlocks caused by both parties waiting for the other party's TxSignatures message at the same time.\n\n### ChannelReady\n\nAfter completing the signing and broadcasting the funding transaction, both parties send ChannelReady messages to each other to indicate the channel is ready.\n\n```\ntable ChannelReady {\n    channel_id: Byte32,\n}\n```\n\n## Transaction Collaboration",
+      "content": "### CommitmentSigned\n\nAfter both parties establish the funding transaction and complete the signing of the commitment transaction in the [Transaction Collaboration](#Transaction-Collaboration) process, they will send CommitmentSigned messages to each other.\n\n```\ntable CommitmentSigned {\n    channel_id:        Byte32,\n\tpartial_signature: Byte32,\n    next_local_nonce:  Byte66,\n}\n```\n\nThe meaning of each field is as follows:\n\n- partial_signature: The partial signature for unlocking the 2-2 Schnorr multisig.\n- next_local_nonce: Used for generating the next commitment transaction partial signature.\n\n### TxSignatures",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-901",
       "title": "Fiber P2P Message Protocol",
-      "content": "In the fiber network, the channel initiator begins the transaction construction protocol using the TxUpdate message. The responder replies with either TxUpdate or TxComplete messages. The transaction construction process is completed when both nodes have sent and received consecutive TxComplete messages.\n\nHere is the `Dual Funding` example, A initially funds part of the channel (2 inputs), then B adds their contribution (1 input). A replies with TxComplete, and B responds with TxComplete, completing the transaction construction process.",
+      "content": "After both parties have signed the commitment transaction and verified the correctness of each other's signatures, they need to send TxSignatures messages to each other to complete the signing of the funding transaction.\n\n```\ntable TxSignatures {\n    channel_id: Byte32,\n    tx_hash:    Byte32,\n    witnesses:  BytesVec,\n}\n```\n\nHere, tx_hash is the hash of the corresponding funding transaction, and witnesses corresponds to the signed witnesses of all inputs of the contributor. If a party's contribution is 0 (i.e., no inputs), an empty witnesses message should also be sent to complete the message exchange.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-902",
       "title": "Fiber P2P Message Protocol",
-      "content": "```\n    +-------+                       +-------+\n    |       |--(1)- tx_update   --->|       |\n    |       |<-(2)- tx_update   ----|       |\n    |   A   |--(3)- tx_complete --->|   B   |\n    |       |<-(4)- tx_complete ----|       |\n    +-------+                       +-------+\n```\n\nSince CKB's transaction structure is more complex than Bitcoin's, the message structure is simplified compared to BOLT 02 interactive transaction construction. We use the full CKB transaction structure for transaction collaboration, without defining separate messages like tx_add_input, tx_add_output, tx_remove_input, and tx_remove_output. Nodes are required to parse the inputs of the transactions and do not need to provide previous tx in the messages. The specific message definitions are as follows:",
+      "content": "In addition, in order to simplify the message interaction process, we defined that the party with the lesser amount of funding must send the\nTxSignatures message first, in the case of the same amount, the one with the smaller funding_pubkey must send the TxSignatures message first. This avoids deadlocks caused by both parties waiting for the other party's TxSignatures message at the same time.\n\n### ChannelReady\n\nAfter completing the signing and broadcasting the funding transaction, both parties send ChannelReady messages to each other to indicate the channel is ready.\n\n```\ntable ChannelReady {\n    channel_id: Byte32,\n}\n```\n\n## Transaction Collaboration",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-903",
       "title": "Fiber P2P Message Protocol",
-      "content": "### TxUpdate\n\nThe TxUpdate message is used by the channel initiator to start the transaction construction protocol.\n\n```\ntable TxUpdate {\n    channel_id: Byte32,\n    tx:         Transaction,\n}\n```\n\nBoth parties must save the funding tx field of the previous message to compare it with the latest message field. They must also mark which inputs/outputs belong to their side. If a TxUpdate message from the other party removes or modifies inputs/outputs from their side, it is considered an illegal operation, and the entire process should be terminated.\n\n### TxComplete\n\nAfter successfully exchanging TxComplete messages, both parties should have constructed the transaction and move to the next part of the protocol to exchange signatures for the commitment transaction.",
+      "content": "In the fiber network, the channel initiator begins the transaction construction protocol using the TxUpdate message. The responder replies with either TxUpdate or TxComplete messages. The transaction construction process is completed when both nodes have sent and received consecutive TxComplete messages.\n\nHere is the `Dual Funding` example, A initially funds part of the channel (2 inputs), then B adds their contribution (1 input). A replies with TxComplete, and B responds with TxComplete, completing the transaction construction process.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-904",
       "title": "Fiber P2P Message Protocol",
-      "content": "```\ntable TxComplete {\n    channel_id: Byte32,\n}\n```\n\n### TxAbort\n\nDuring the transaction collaboration process, a node can send a TxAbort message to terminate the collaboration before sending the TxSignatures message.\n\n```\ntable TxAbort {\n    channel_id: Byte32,\n    message:    Bytes,\n}\n```\n\n### TxInitRbf\n\nAfter broadcasting the funding transaction, if the channel initiator finds that the fee is insufficient, they can send a TxInitRbf message to request the other party's cooperation in performing RBF (Replace-By-Fee) operation to increase the fee and rebroadcast the funding transaction.\n\n```\ntable TxInitRBF {\n    channel_id: Byte32,\n    fee_rate:   Uint64,\n}\n```\n\n### TxAckRbf",
+      "content": "```\n    +-------+                       +-------+\n    |       |--(1)- tx_update   --->|       |\n    |       |<-(2)- tx_update   ----|       |\n    |   A   |--(3)- tx_complete --->|   B   |\n    |       |<-(4)- tx_complete ----|       |\n    +-------+                       +-------+\n```\n\nSince CKB's transaction structure is more complex than Bitcoin's, the message structure is simplified compared to BOLT 02 interactive transaction construction. We use the full CKB transaction structure for transaction collaboration, without defining separate messages like tx_add_input, tx_add_output, tx_remove_input, and tx_remove_output. Nodes are required to parse the inputs of the transactions and do not need to provide previous tx in the messages. The specific message definitions are as follows:",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-905",
       "title": "Fiber P2P Message Protocol",
-      "content": "Upon receiving a TxInitRbf message, the channel responder can send a TxAckRbf message to agree to the RBF operation.\n\n```\ntable TxAckRBF {\n    channel_id: Byte32,\n}\n```\n\nAfter receiving the TxAckRbf message from the other party, the channel initiator can restart the process of funding transaction collaboration with the new fee rate. It should be noted that the new funding transaction must have overlapping inputs with the previous funding transaction to ensure it meets the RBF rules.\n\n## Channel Closing\n\nNodes can negotiate to close a channel mutually, unlike a unilateral close, which allows nodes to immediately obtain funds. The process of closing a channel is as follows:",
+      "content": "### TxUpdate\n\nThe TxUpdate message is used by the channel initiator to start the transaction construction protocol.\n\n```\ntable TxUpdate {\n    channel_id: Byte32,\n    tx:         Transaction,\n}\n```\n\nBoth parties must save the funding tx field of the previous message to compare it with the latest message field. They must also mark which inputs/outputs belong to their side. If a TxUpdate message from the other party removes or modifies inputs/outputs from their side, it is considered an illegal operation, and the entire process should be terminated.\n\n### TxComplete\n\nAfter successfully exchanging TxComplete messages, both parties should have constructed the transaction and move to the next part of the protocol to exchange signatures for the commitment transaction.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-906",
       "title": "Fiber P2P Message Protocol",
-      "content": "```\n    +-------+                             +-------+\n    |       |--(1)- shutdown           -->|       |\n    |       |<-(2)- shutdown           ---|       |\n    |   A   | <complete all pending TLCs> |   B   |\n    |       |<-(3)- closing_signed     ---|       |\n    |       |--(4)- closing_signed     -->|       |\n    +-------+                             +-------+\n```\n\n### Shutdown\n\nAny node can send a Shutdown message to request the closure of the channel.\n\n```\ntable Shutdown {\n    channel_id:   Byte32,\n    close_script: Script,\n    fee_rate:     Uint64,\n}\n```\n\nThe close_script specifies the lock script to which the assets will be sent when the channel is closed.\n\n### ClosingSigned",
+      "content": "```\ntable TxComplete {\n    channel_id: Byte32,\n}\n```\n\n### TxAbort\n\nDuring the transaction collaboration process, a node can send a TxAbort message to terminate the collaboration before sending the TxSignatures message.\n\n```\ntable TxAbort {\n    channel_id: Byte32,\n    message:    Bytes,\n}\n```\n\n### TxInitRbf\n\nAfter broadcasting the funding transaction, if the channel initiator finds that the fee is insufficient, they can send a TxInitRbf message to request the other party's cooperation in performing RBF (Replace-By-Fee) operation to increase the fee and rebroadcast the funding transaction.\n\n```\ntable TxInitRBF {\n    channel_id: Byte32,\n    fee_rate:   Uint64,\n}\n```\n\n### TxAckRbf",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-907",
       "title": "Fiber P2P Message Protocol",
-      "content": "After completing all pending Time Locked Contracts (TLCs) in the channel, either party can send a ClosingSigned message to sign the close transaction.\n\n```\ntable ClosingSigned {\n    channel_id:         Byte32,\n    partial_signature:  Byte32,\n}\n```\n\nIf the receiver verified the correctness of the signature, they will respond with a ClosingSigned message, completing the channel closure.\n\n## Payment Operation\n\nAfter establishing a channel, nodes can perform payment operations by sending AddTlc messages for payment requests and then updating the commitment transactions through CommitmentSigned and RevokeAndAck messages. Here is an example process:",
+      "content": "Upon receiving a TxInitRbf message, the channel responder can send a TxAckRbf message to agree to the RBF operation.\n\n```\ntable TxAckRBF {\n    channel_id: Byte32,\n}\n```\n\nAfter receiving the TxAckRbf message from the other party, the channel initiator can restart the process of funding transaction collaboration with the new fee rate. It should be noted that the new funding transaction must have overlapping inputs with the previous funding transaction to ensure it meets the RBF rules.\n\n## Channel Closing\n\nNodes can negotiate to close a channel mutually, unlike a unilateral close, which allows nodes to immediately obtain funds. The process of closing a channel is as follows:",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-908",
       "title": "Fiber P2P Message Protocol",
-      "content": "```\n    +-------+                               +-------+\n    |       |--(1)---- add_tlc         ---->|       |\n    |       |                               |       |\n    |       |--(2)---- commitment_signed -->|       |\n    |       |<-(3)---- revoke_and_ack  -----|       |\n    |       |                               |       |\n    |       |<-(4)---- commitment_signed ---|       |\n    |       |--(5)---- revoke_and_ack  ---->|       |\n    |       |                               |       |\n    |   A   |                               |   B   |\n    |       |                               |       |\n    |       |<-(6)---- remove_tlc      -----|       |\n    |       |                               |       |\n    |       |<-(7)---- commitment_signed ---|       |\n    |       |--(8)---- revoke_and_ack  ---->|       |\n    |       |                               |       |\n    |       |--(9)---- commitment_signed -->|       |\n    |       |<-(10)---- revoke_and_ack  ----|       |\n    +-------+                               +-------+\n```",
+      "content": "```\n    +-------+                             +-------+\n    |       |--(1)- shutdown           -->|       |\n    |       |<-(2)- shutdown           ---|       |\n    |   A   | <complete all pending TLCs> |   B   |\n    |       |<-(3)- closing_signed     ---|       |\n    |       |--(4)- closing_signed     -->|       |\n    +-------+                             +-------+\n```\n\n### Shutdown\n\nAny node can send a Shutdown message to request the closure of the channel.\n\n```\ntable Shutdown {\n    channel_id:   Byte32,\n    close_script: Script,\n    fee_rate:     Uint64,\n}\n```\n\nThe close_script specifies the lock script to which the assets will be sent when the channel is closed.\n\n### ClosingSigned",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-909",
       "title": "Fiber P2P Message Protocol",
-      "content": "### AddTlc\n\nEither node can send an AddTlc message to the other party to initiate a payment operation. This message can also be used to forward payment requests from other nodes.\n\n```\ntable AddTlc {\n    channel_id:     Byte32,\n    tlc_id:         Uint64,\n    amount:         Uint128,\n    payment_hash:   Byte32,\n    expiry:         Uint64,\n}\n```",
+      "content": "After completing all pending Time Locked Contracts (TLCs) in the channel, either party can send a ClosingSigned message to sign the close transaction.\n\n```\ntable ClosingSigned {\n    channel_id:         Byte32,\n    partial_signature:  Byte32,\n}\n```\n\nIf the receiver verified the correctness of the signature, they will respond with a ClosingSigned message, completing the channel closure.\n\n## Payment Operation\n\nAfter establishing a channel, nodes can perform payment operations by sending AddTlc messages for payment requests and then updating the commitment transactions through CommitmentSigned and RevokeAndAck messages. Here is an example process:",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-910",
       "title": "Fiber P2P Message Protocol",
-      "content": "- channel_id: ID of the channel.\n- tlc_id: ID of the TLC (Time Locked Contract), used to uniquely identify a TLC. The first TLC in the channel has an ID of 0, and subsequent IDs increment by 1.\n- amount: Amount of assets requested for payment.\n- payment_hash: Hash value used to identify the payment request for subsequent payment verification.\n- expiry: Expiry time of the payment request, specified as an absolute timestamp. When forwarding a payment request, this field should be decremented appropriately.\n\n## RevokeAndAck\n\nUpon receiving the CommitmentSigned message and verifying the signature, the node may reveal the previous commitment transaction secret to the other party by sending a RevokeAndAck message.",
+      "content": "```\n    +-------+                               +-------+\n    |       |--(1)---- add_tlc         ---->|       |\n    |       |                               |       |\n    |       |--(2)---- commitment_signed -->|       |\n    |       |<-(3)---- revoke_and_ack  -----|       |\n    |       |                               |       |\n    |       |<-(4)---- commitment_signed ---|       |\n    |       |--(5)---- revoke_and_ack  ---->|       |\n    |       |                               |       |\n    |   A   |                               |   B   |\n    |       |                               |       |\n    |       |<-(6)---- remove_tlc      -----|       |\n    |       |                               |       |\n    |       |<-(7)---- commitment_signed ---|       |\n    |       |--(8)---- revoke_and_ack  ---->|       |\n    |       |                               |       |\n    |       |--(9)---- commitment_signed -->|       |\n    |       |<-(10)---- revoke_and_ack  ----|       |\n    +-------+                               +-------+\n```",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-911",
       "title": "Fiber P2P Message Protocol",
-      "content": "```\ntable RevokeAndAck {\n    channel_id:                 Byte32,\n    per_commitment_secret:      Byte32,\n    next_per_commitment_point:  Byte33,\n    next_local_nonce:           Byte66,\n}\n```\n\n- per_commitment_secret: Secret used to generate the revocation secret key for the previous commitment transaction.\n- next_per_commitment_point: Point used to generate the next revocation public key.\n- next_local_nonce: Used for generating the partial signature for the next commitment transaction.\n\nUpon receiving the RevokeAndAck message, the node should update the remote commitment transaction.\n\n## RemoveTlc\n\nTo simplify the implementation, only the recipient of the AddTkc message can remove the TLC.",
+      "content": "### AddTlc\n\nEither node can send an AddTlc message to the other party to initiate a payment operation. This message can also be used to forward payment requests from other nodes.\n\n```\ntable AddTlc {\n    channel_id:     Byte32,\n    tlc_id:         Uint64,\n    amount:         Uint128,\n    payment_hash:   Byte32,\n    expiry:         Uint64,\n}\n```",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-912",
       "title": "Fiber P2P Message Protocol",
-      "content": "```\ntable RemoveTlc {\n    channel_id:         Byte32,\n    tlc_id:             Uint64,\n    reason:             RemoveTlcReason\n}\n\nunion RemoveTlcReason {\n    RemoveTlcFulfill,\n    RemoveTlcFail,\n}\n\nstruct RemoveTlcFulfill {\n    payment_preimage:   Byte32,\n}\n\nstruct RemoveTlcFail {\n    error_code:         Uint32,\n}\n```\n\n- channel_id: ID of the channel.\n- tlc_id: ID of the TLC being removed.\n- reason: Reason for removing the TLC, which can be either RemoveTlcFulfill or RemoveTlcFail.\n    - RemoveTlcFulfill: Contains the payment_preimage required to fulfill the payment.\n    - RemoveTlcFail: Contains an error_code indicating the reason for failure.",
+      "content": "- channel_id: ID of the channel.\n- tlc_id: ID of the TLC (Time Locked Contract), used to uniquely identify a TLC. The first TLC in the channel has an ID of 0, and subsequent IDs increment by 1.\n- amount: Amount of assets requested for payment.\n- payment_hash: Hash value used to identify the payment request for subsequent payment verification.\n- expiry: Expiry time of the payment request, specified as an absolute timestamp. When forwarding a payment request, this field should be decremented appropriately.\n\n## RevokeAndAck\n\nUpon receiving the CommitmentSigned message and verifying the signature, the node may reveal the previous commitment transaction secret to the other party by sending a RevokeAndAck message.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-913",
       "title": "Fiber P2P Message Protocol",
-      "content": "[BOLT 02]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#channel-establishment-v2\n[Molecule]: https://github.com/nervosnetwork/molecule\n[Secret Derivations]: https://github.com/lnbook/lnbook/blob/54453c7b1cf82186614ab929b80876ba18bdc65d/07_payment_channels.asciidoc#revocation_sidebar",
+      "content": "```\ntable RevokeAndAck {\n    channel_id:                 Byte32,\n    per_commitment_secret:      Byte32,\n    next_per_commitment_point:  Byte33,\n    next_local_nonce:           Byte66,\n}\n```\n\n- per_commitment_secret: Secret used to generate the revocation secret key for the previous commitment transaction.\n- next_per_commitment_point: Point used to generate the next revocation public key.\n- next_local_nonce: Used for generating the partial signature for the next commitment transaction.\n\nUpon receiving the RevokeAndAck message, the node should update the remote commitment transaction.\n\n## RemoveTlc\n\nTo simplify the implementation, only the recipient of the AddTkc message can remove the TLC.",
       "url": "/docs/res/p2p-message",
       "source": "docs/res/p2p-message.mdx"
     },
     {
       "id": "chunk-914",
+      "title": "Fiber P2P Message Protocol",
+      "content": "```\ntable RemoveTlc {\n    channel_id:         Byte32,\n    tlc_id:             Uint64,\n    reason:             RemoveTlcReason\n}\n\nunion RemoveTlcReason {\n    RemoveTlcFulfill,\n    RemoveTlcFail,\n}\n\nstruct RemoveTlcFulfill {\n    payment_preimage:   Byte32,\n}\n\nstruct RemoveTlcFail {\n    error_code:         Uint32,\n}\n```\n\n- channel_id: ID of the channel.\n- tlc_id: ID of the TLC being removed.\n- reason: Reason for removing the TLC, which can be either RemoveTlcFulfill or RemoveTlcFail.\n    - RemoveTlcFulfill: Contains the payment_preimage required to fulfill the payment.\n    - RemoveTlcFail: Contains an error_code indicating the reason for failure.",
+      "url": "/docs/res/p2p-message",
+      "source": "docs/res/p2p-message.mdx"
+    },
+    {
+      "id": "chunk-915",
+      "title": "Fiber P2P Message Protocol",
+      "content": "[BOLT 02]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#channel-establishment-v2\n[Molecule]: https://github.com/nervosnetwork/molecule\n[Secret Derivations]: https://github.com/lnbook/lnbook/blob/54453c7b1cf82186614ab929b80876ba18bdc65d/07_payment_channels.asciidoc#revocation_sidebar",
+      "url": "/docs/res/p2p-message",
+      "source": "docs/res/p2p-message.mdx"
+    },
+    {
+      "id": "chunk-916",
       "title": "What is Payment Channel Network",
       "content": "Layer 2 is a popular solution to the blockchain scalability problem, which, unlike implementing alternative consensus schemes and side chains, avoids the risk of forking the blockchain. A main approach in layer 2 is to open off-chain channels where two parties communicate for transactions and smart contracts outside of the underlying layer 1 blockchain. The most prominent examples of payment channels include the [lightning network](https://lightning.network/#intro) on Bitcoin and [Raiden](https://raiden.network/) on Ethereum.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-915",
+      "id": "chunk-917",
       "title": "What is Payment Channel Network",
       "content": "Payment channels can be *unidirectional* or *bidirectional*, depending on the flow direction of the payments. In unidirectional channels, the payment is only from one party to another, not the other way around. It works like a top-up card, where you deposit some money off-chain, and transfer a certain amount within the fund limit to the receiver with your signature. When closing the channel, or the channel going depletion, the final balance information is updated on-chain hence completes the payments. In bidirectional channels, both party make a deposit to the channel at opening (this procedure is called *funding*). The problem for directly using a unidirectional channel is that, every transaction between the parties is authenticated, therefore a malicious party is able to claim previous transactions where the balance is in favor of oneself. The lightning network solved this problem by preventing any user to redeem older states, i.e., when a new transaction is signed in a bidirectional channel, the players reveal a secret information to the previous transaction for revocation.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-916",
+      "id": "chunk-918",
       "title": "What is Payment Channel Network",
       "content": "Off-chain bidirectional payment channels with a multi-hop protocol form a payment channel network (PCN) to handle off-chain payments between two players who have no direct channel themselves. If Alice wants to send coins through an intermediary Ingrid, a crucial difficulty is the lack of trust between Alice and Ingrid. Ingrid receives a fee for doing the favor, but she worries that Alice might refuse to pay after she pays Bob. Similarly, Alice couldn't simply give the money to Ingrid and pray that Ingrid would not take the money and disappear. This is why *Hash Time Lock Contract* (HTLC) was invented. In an HTLC between Alice and Ingrid, there are two locks, a *time lock* and a *hash lock*. Ingrid gets the coins if she can solve the hash lock puzzle, which requires the pre-image of a predefined hash digest (chosen by the receiver Bob) before timeout; while Alice gets the coins in the contract after the end of the time lock if Ingrid fails to provide a correct pre-image in time.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-917",
+      "id": "chunk-919",
       "title": "What is Payment Channel Network",
       "content": "In payment channel network protocols with HTLC-like schemes, the collateral that the parties have to pay as a cost is often defined as the product of the deposited fund and the total time. Therefore, a considerable amount of assets are locked in the channels, which poses a non-negligible negative influence on the liquidity. For instance, 30 percent of the lightning network locks approximately 890BTC of collateral with a value of 39M USD (value estimated by the time [the paper](https://eprint.iacr.org/2021/1445) on sleepy channels was written). In addition, the network topology of a payment channel network is mostly hidden for protecting the anonymous relationship and balance privacy of the players. So routing in PCN, that is to find a payment path with minimal fees and optimized efficiency, is challenging in general.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-918",
+      "id": "chunk-920",
       "title": "What is Payment Channel Network",
       "content": "To mitigate the routing problem, payment channel hub (PCH) is a promising alternative. In a PCH, a trusted *tumbler* plays a centralized role to forward the payments from a sender to a receiver. One of the first PCH schemes was proposed by [Heilman et al.](https://www.ndss-symposium.org/ndss2017/ndss-2017-programme/tumblebit-untrusted-bitcoin-compatible-anonymous-payment-hub/) at NDSS 17, which is unidirectional, unlinkable, privacy-enhanced and Bitcoin-compatible. Here, the trust between Alice and the tumbler is a reversed version of the HTLC, in which the sender Alice needs to solve a hash puzzle to prove that she has paid the tumbler. [Perun](https://ieeexplore.ieee.org/document/8835315) proposed by Dziembowski et al. at S&P19 presented a PCH scheme for constructing virtual channels. Perun is implemented on Ethereum with Turing-complete smart contracts. A more recent PCH protocol is [A2L](https://ieeexplore.ieee.org/abstract/document/9519431) designed by Tairi et al. at S&P21. A2L gives the first PCH construction that requires minimal properties of the blockchain with only digital signatures and time-locks.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-919",
+      "id": "chunk-921",
       "title": "What is Payment Channel Network",
       "content": "PCN players are expected to monitor the channel state regularly and frequently to detect frauds in time. However, in practice, this might bring a unbearable cost for the players, and fund lose is likely to happen if the frauds are overlooked accidentally. Especially, when an intermediary in a payment path goes offline for a long time, it greatly decreases the efficiency and success rate of the transactions. One solution is to hire watchtowers to supervise the channels for players when they are offline, and resolve possible disputes with the snapshots stored by the watchtowers. We will talk more about watchtowers later. Another approach is to build virtual channels based on payment channels. Virtual channels are off-chain channels that allow players with no direct payment channel to communicate off-chain without an intermediary. Only the open and closure of virtual channels require the participation of an intermediary node, . Perun presented such virtual channels with smart contracts. Later at S&P21, a bitcoin-compatible virtual channel scheme was proposed by [Aumayr et al.](https://ieeexplore.ieee.org/document/9519487) to remove the dependency on smart contracts. An interesting question here is whether it is possible to build virtual channels based on virtual channels.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-920",
+      "id": "chunk-922",
       "title": "What is Payment Channel Network",
       "content": "A generalization of payment channels is studied to deploy off-chain smart contracts, those are called *state channels* or *generalized channels*, e.g., the general state channel networks presented at CCS18 by [Dziembowski et al.](https://dl.acm.org/doi/10.1145/3243734.3243856). State channels can be extended in a virtual multi-party setting as studied by  Dziembowski et al. in [this Eurocrypt19 paper](https://link.springer.com/chapter/10.1007/978-3-030-17653-2_21). [Hydra](https://eprint.iacr.org/2020/299), proposed by Chakravarty et al. at FC21 takes advantage of the extended UTxO model to reuse the on-chain smart contract system. The studies on state channels and virtual channels are fewer comparing with those on lightning networks and PCN protocols.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-921",
+      "id": "chunk-923",
       "title": "What is Payment Channel Network",
       "content": "In the following, we will discuss on several highlighted topics in the research of payment channel networks.\n\n## Hash Time Lock Contracts\n\nHTLC is a vital component in the implementation of lightning network and cross-chain atomic swap protocols. The core idea is that the players deposit a certain amount of collaterals in the channel and claims the money under conditions in order to prevent frauds. However, HTLC has vulnerabilities that jeopardize the security and privacy of the network under a malicious exploration. In this section, we will talk about the security issues including bribery attacks, DoS and congestion attacks. Then we discuss the improvements on HTLC for multi-hop multi-party use cases.\n\n### **Bribery Attack**",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-922",
+      "id": "chunk-924",
       "title": "What is Payment Channel Network",
       "content": "Bribery attack is a common threat to blockchain users by encouraging dishonest strategies with malicious incentives. In the honest case, when Alice sends coins to Bob through Ingrid, we have two HTLCs for Alice with Ingrid, and, Ingrid with Bob. When claiming the money, Ingrid receives the pre-image of the hash lock from Bob before the expiration of the second contract, then Ingrid gets redeemed from Alice by forwarding the correct pre-image to her before timeout. To include a transaction on-chain, transaction fees are paid to miners so they pack the transactions and mine a block. In a bribery attack, Alice refuses to pay Ingrid even if Ingrid shows the correct pre-image. Alice achieved so by bribing the miners such that they ignore Ingrid's transaction and leave it unpacked till timeout. The fund lose of Ingrid incentivizes the miners and Alice to collude and gain. This attack breaks the atomicity principle of the payment channel network.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-923",
+      "id": "chunk-925",
       "title": "What is Payment Channel Network",
       "content": "The idea of such a bribery attack is originated from [this EuroS&PW19 paper](https://ieeexplore.ieee.org/document/8802377) on temporary censorship attacks by Winzer et al.. The authors presented three types of briberies on smart contracts. The bribery per miner strategy is the most expensive one with a quadratic collateral to the number of participants, it requires to pay all the miners a fixed amount of money. Pay per block is less costly but there is a risk that the other miners who are not paid choose not to cooperate. Pay-per-commit ignores the honest transaction through a public commit by a high-mining power miner to a malicious mining strategy. Such a bribery to miners is studied in HTLC by Tsabery et al. in the SP21 paper [MAD-HTLC](https://ieeexplore.ieee.org/document/9519476). It considered the incentives of the miners to act in an evil strategy, and provided a game-theoretical analysis of the participants with sub-game perfect equilibrium. An improved HTLC protocol MAD-HTLC is proposed to punish the briber, which gives the confiscate coins to the miner if the sender intends to bribe. A similar idea was proposed in a concurrent paper by Nadahalli et al. at FC21 with a [timelocked bribing](https://link.springer.com/chapter/10.1007/978-3-662-64322-8_3). [HE-HTLC](https://www.ndss-symposium.org/wp-content/uploads/2023/02/ndss2023_f775_paper.pdf), proposed by Wadhwa et al., further extended the bribery attacks in MAD-HTLC by considering a reversed bribery, meaning that the miners bribes Alice for her to trust and collude. Then at FC22, the incentives for the bribery attacks in MAD-HTLC are generalized in [Suborn](https://link.springer.com/chapter/10.1007/978-3-031-18283-9_24) by Avarikioti et al., the aim is to adjust the transaction fees to disincentivize bribes.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-924",
+      "id": "chunk-926",
       "title": "What is Payment Channel Network",
       "content": "### **DoS Attack**",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-925",
+      "id": "chunk-927",
       "title": "What is Payment Channel Network",
       "content": "Similar to bribery, an attacker can ignore or exclude an honest transaction by disabling the network with DoS or congestion attacks. For instance, in the [flood&loot](https://dl.acm.org/doi/10.1145/3419614.3423248) attack presented by Harris et al. at AFT20, an attacker floods the payment channel network by starting many small transactions all at once, such that the system doesn't have enough power to take care of the honest transactions before timeout. Such an attack is dangerous for lightning network, because the attack gets a loot by disabling merely 85 channels. [Congestion attack](https://dl.acm.org/doi/10.1007/978-3-662-64331-0_9) proposed by Mizrahi et al. at FC21 takes advantage of the Max HTLC limit in the protocol, sending transactions to the attacker itself, to block the channels with high liquidity.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-926",
+      "id": "chunk-928",
       "title": "What is Payment Channel Network",
       "content": "### **Atomicity**\n\nAnother often mentioned HTLC vulnerability is the partial atomicity problem, which leads to the [wormhole attack](https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_09-4_Malavolta_paper.pdf) presented at NDSS19 by Malavolta et al.. Although HTLC maintains the atomicity in one-hop transactions, a malicious attacker can take advantage of the multi-hop transaction by participating in two or more nodes in the multi-hop path. Then, once the pre-image is known to the attacker, all the nodes between attacker's nodes are skipped and they lose coins to the attacker.\n\n### **Multi-Hop Multi-Party HTLCs**",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-927",
+      "id": "chunk-929",
       "title": "What is Payment Channel Network",
       "content": "Improved HTLC schemes have been proposed to overcome the vulnerabilities of HTLC and to provide advanced properties. For instance, at the conference CCS17 by Malavolta et al., [concurrency and privacy](https://dl.acm.org/doi/10.1145/3133956.3134096) are formalized in the universal composability framework and two protocols were design to achieve the properties. In addition, they presented an improved *multi-hop HTLC contract*, which protects the privacy of the players in a payment path with multiple intermediaries. For each player, he or she only knows who is directly talking to in the path, but has no idea about the identity of the sender and receiver in the payment. In atomic cross-chain swap exchanges, players from different blockchains trade their tokens in a fair and trustless way. Narayanam et al. constructed an HTLC contract for multi-party cross-chain exchange at AFT22. What I find interesting is that such an HTLC contract allows multiple players to own and trade assets jointly with the help of MPC. It is called [MP-HTLC](https://arxiv.org/abs/2202.12855).",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-928",
+      "id": "chunk-930",
       "title": "What is Payment Channel Network",
       "content": "## Security and Privacy Topics in PCN\n\nIn this section, we will focus on the vulnerabilities of current PCN protocols in security and privacy. Being a communication network, PCN protocols suffer from typical attacks on network topology. In addition, the economics incentives in PCN play a significant role in the participants of the protocol.\n\n### **Privacy Attacks**\n\nIn FC21, [Kappos et al.](https://dl.acm.org/doi/abs/10.1007/978-3-662-64322-8_8) defined four types of privacy notions in payment channel networks.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-929",
+      "id": "chunk-931",
       "title": "What is Payment Channel Network",
       "content": "- *Private channels*. When two users share a channel, other participants in the network have no idea about the existence of the channel and identity information.\n- *Third-party secrecy*. The balance of the channel is kept secret from any third party.\n- *On-path relationship anonymity*. For a honest but curious participant on a payment path, the payment relationship should be anonymous. In lightning network, this might be a vulnerable problem because of its centrality.\n- *Off-path payment privacy*. Nodes outside the payment path should know nothing about the payment value.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-930",
+      "id": "chunk-932",
       "title": "What is Payment Channel Network",
       "content": "The attacks on privacy we discuss here are mostly on the second and third properties. There is a [timing attack](https://dl.acm.org/doi/10.1145/3419614.3423262) by Rohrer et al. at AFT20 for finding the sender and receiver in a payment path by exploring the related transaction amounts in the payment path and the decreasing deadline in the time locks of the HTLC. Channel balance is also a frequent attacking target. Revealing the balance might lead to unfair fees and malicious attacks on the network. For instance, a [lockdown attack](https://dl.acm.org/doi/abs/10.1007/978-3-030-51280-4_14) by Pérez-Solà at FC20 showed that, using a DoS attack, it is possible to freeze the balances in many channels, so that the critical nodes in the network are blocked thus paralyzes the PCN. Later, a [probing attack](https://link.springer.com/chapter/10.1007/978-3-031-18283-9_16) is proposed by Biryukov et al. at FC22, the authors show geometric strategies to optimize the success probability and attack speed in probing the balance in the channels. A probing attacker sends invalid transactions or transactions to another address owned by the attacker, to find out if the balance of a channel player is larger or smaller than the probing value. This strategy is more efficient than a default binary search. Also, it works when there are multiple channels between the attacker and the probed node.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-931",
+      "id": "chunk-933",
       "title": "What is Payment Channel Network",
       "content": "Due to the privacy concerns, the network topology is unknown in the lightning network and many other PCN networks, which raises new challenges like routing issues in the next subsection. The question studied in Sigmetric20 paper by [Tang et al.](https://dl.acm.org/doi/10.1145/3393691.3394213) answers whether it is possible to achieve a tradeoff between privacy and utility/efficiency.\n\n### **Routing Issue**",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-932",
+      "id": "chunk-934",
       "title": "What is Payment Channel Network",
       "content": "When Alice sends Bob coins through the network, she prefers a path that every channel in the path contains enough balance for the transfer and the total transaction fee of the path is as small as possible. This task is difficult because of the unknown network topology, potential depleted channels, and constantly changing channel balances. A simple strategy is to try many channels and detect one that happens to work.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-933",
+      "id": "chunk-935",
       "title": "What is Payment Channel Network",
       "content": "An early routing algorithm as used in [SlientWhispers](https://www.ndss-symposium.org/ndss2017/ndss-2017-programme/silentwhispers-enforcing-security-and-privacy-decentralized-credit-networks/) by Malavolta et al. at NDSS17 and [SpeedyMurmurs](https://www.ndss-symposium.org/wp-content/uploads/2018/02/ndss2018_09-3_Roos_paper.pdf) by Roos et al. at NDSS18 are based on landmarks. The idea of a landmark routing protocol is to calculate a path between sender and receiver through an intermediary node called a landmark. In more detail, landmarks are selected nodes which are well known to every other node in the network. [FSTR](https://ieeexplore.ieee.org/document/9153423) routing proposed at DSN20 by Lin et al. is based on the fund skewness properties, which considers the imbalance in the channels. This is at the cost of privacy.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-934",
+      "id": "chunk-936",
       "title": "What is Payment Channel Network",
       "content": "To reduce the unsuccessful probability of transaction in a routing procedure, it is possible to split the transaction value to smaller portions and transfer them through multiple paths, so that the balances in the paths are more likely to match the transaction. [Spider](https://www.usenix.org/conference/nsdi20/presentation/sivaraman) by Sivaraman et al. at NSDI20 presented a multi-path routing protocol to packetizes the transactions. Later on, in [Boomerang](https://fc20.ifca.ai/preproceedings/12.pdf) designed by Bagaria et al. at FC20 and [Spear](https://dl.acm.org/doi/10.1145/3479722.3480997) by Rahimpour et al. at FC21, a redundant payment path strategy is studied. To show the idea with an example, say, instead of sending 4 coins through 4 channels each with one coin, the sender sends 8 coins through 8 channels each with one coin, and the protocol terminates when 4 out of 8 coins are received. It is ensured by verifiable secret sharing that the remaining 4 coins won't be stolen in the channels. Spear is an improved scheme on boomerang, it has lower latency and smaller computation because it doesn't use the cryptographic primitives as those in boomerang. Lastly, presented at AFT20 by [Tochner et al.](https://dl.acm.org/doi/abs/10.1145/3419614.3423253), an attacker can strategically influence and explore the pattern that transactions are routed in the network. Through a DoS attack, an attacker is able to hijack some routes like in the [bitcoin hijacking attack](https://ieeexplore.ieee.org/document/7958588) by Apostolaki et al. at S&P17 and forces the payment to go through the routes preferred by the attacker. The gain of the attacker might be the liquidity locked in the network, or transaction fees through attacker's network (even though the fee is higher than others thus not preferable when not attacked).",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-935",
+      "id": "chunk-937",
       "title": "What is Payment Channel Network",
       "content": "### **Rebalancing**",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-936",
+      "id": "chunk-938",
       "title": "What is Payment Channel Network",
       "content": "In payment channel networks, the initial collaterals in each channel might deplete after a while, because one party pays more to the other. When a channel depletes, a naive solution is to close the channel and reopen a new one on-chain. For instance, Loop on the lightning network achieves such a goal. However, it takes time and money to do so. A better solution is rebalancing, as first proposed in [Revive](https://dl.acm.org/doi/10.1145/3133956.3134033) by Khalil et al. at CCS17. The idea is as follows. When Alice's balance ran out in channel 1, and she has enough balance in channel 2 with another party, she can make a transfer to herself into channel 1 to top-up through channel 2 without going on-chain. Revive has several practical problems, first, a delegate is required to handle the rebalance process, in addition, it requires the cooperation of other participants in the network, lastly, it is difficult to route the rebalancing path in a large network with an unknown topology. What's worse, the rebalanced amount by Revive is bounded by the smallest channel balance in the path.  [Hide&seek](https://fc22.ifca.ai/preproceedings/152.pdf) by Avarikioti1 et al. at FC22 studied a linear programming problem in scheduling the rebalancing amount and direction to achieve minimum cost. [Cycle](https://ieeexplore.ieee.org/document/9833795) by Hong et al. at DSN22 proposed to constantly rebalancing to make sure that channels don't go depletion. To avoid a cyclic path to rebalance, [Shaduf](https://www.ndss-symposium.org/ndss-paper/auto-draft-254/) by Ge et al. at NDSS22 gives a non-cycle rebalancing protocol, it doesn't require the rebalancing path to form a cycle. This process is done by binding two channels together for moving the coins between them, and declare such a binding on-chain.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-937",
+      "id": "chunk-939",
       "title": "What is Payment Channel Network",
       "content": "Of course, there is another question to answer, how much money should the players deposit in the channel at the opening phase? Li et al.  gives a balance planning service at infocom20 called [PnP](https://ieeexplore.ieee.org/document/9155375) to decide the initial balance to put in the channel.\n\n### **Watchtowers**",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-938",
+      "id": "chunk-940",
       "title": "What is Payment Channel Network",
       "content": "Lastly, we come back at the solutions to deal with offline users or intermediaries in payment channel networks. If a user doesn't want to keep an eye on the channel all the time, it is recommended to hire a watchtower to detect potential frauds. Watchtower has been designed in the lightning network, but it encounters a lack of incentives for the watchtowers to work properly, because the watchtowers are only paid when they find a fraud, but they don't expect to gain a lot because most of the users are honest. So McCorry presented [Pisa](https://webee.technion.ac.il/people/ittay/aft19/aft19-final21.pdf) at AFT19 proposed to pay watchtowers regularly. A drawback is that this scheme is vulnerable to bribery attack. Also it is not friendly to bitcoin because it relies on smart contracts. The second problem is fixed by Mirzaei et al. at FC21 with [FPPW](https://fc21.ifca.ai/papers/51.pdf) to make the watchtower service compatible with the bitcoin. [Outpost](https://eprint.iacr.org/2019/986.pdf), proposed by Khabbazian et al. at AFT19, is one of the first watchtowers that is lightweight (meaning that the watchtower doesn't need to store too much data) and compatible with bitcoin. [Cerberus](https://fc20.ifca.ai/preproceedings/132.pdf) by Avarikioti et al. at FC20 and [Brick](https://fc21.ifca.ai/papers/168.pdf) by Avarikioti et al. at FC21 are schemes with incentives and penalty on watchtowers to encourage them to work properly. And punish the watchtowers if they play evil. [Fail-safe watchtower](https://dl.acm.org/doi/abs/10.1145/3320269.3384716) by Liu et al. at AsiaCCS20 considers attacks like DoS on the watchtower and improved the scheme to protect the service against such attacks. Lastly, Aumayr et al. at CCS22 presented [sleepy channel](https://dl.acm.org/doi/10.1145/3548606.3559370) for users to go offline without hiring watchtowers.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-939",
+      "id": "chunk-941",
       "title": "What is Payment Channel Network",
       "content": "## Improved PCN Protocols\n\nIn the final section of this post, I want to give a quick overview on several improved PCN protocols.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-940",
+      "id": "chunk-942",
       "title": "What is Payment Channel Network",
       "content": "PCN protocols to improve certain properties, such as (global) atomicity, path restriction (for a certain network topology), interoperability(whether smart contracts are required), per party collateral, privacy and so on. Per party collateral is linear in the lightning network, as well as Anonymous Multi-Hop Locks ([AMHL](https://www.ndss-symposium.org/ndss-paper/anonymous-multi-hop-locks-for-blockchain-scalability-and-interoperability/)) by Malavolta et al. at NDSS19. Recent protocols can achieve constant per party collateral, including [Sprites](https://fc19.ifca.ai/preproceedings/185-preproceedings.pdf) by Miller et al. at FC19, Atomic Multi-Channel Updates ([AMCU](https://dl.acm.org/doi/10.1145/3319535.3345666)) by Egger et al. at CCS19, [Blitz](https://www.usenix.org/conference/usenixsecurity21/presentation/aumayr) by Aumayr et al. at Usenix security22, and [Thora](https://dl.acm.org/doi/10.1145/3548606.3560556) by Aumayr et al. at CCS22. Collateral is defined by the payment amount multiplied by the locktime, and it reflects the liquidity of a scheme. Large collaterals make the system vulnerable to griefing attacks, where the attacker's aim is to spoil the network by freezing as much collaterals as possible. Path restriction tells whether a protocol is applicable to other topology like a star shape. I hope to mention that AMCU is vulnerable to channel closure attack as discussed by Jourenko et al. in a scheme called [payment trees](https://dl.acm.org/doi/abs/10.1007/978-3-662-64331-0_10) at FC21 . It worths mentioning that Blitz is without HTLC contracts, which means that it is suitable for blockchains without HTLC. Also, it solves the *staggered collateral problem* in multi-hop HTLCs, which is, the locktime in MP-HTLC is often too long, because you have to leave out enough time for each users to react after one receives the secret.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-941",
+      "id": "chunk-943",
       "title": "What is Payment Channel Network",
       "content": "## About the Author\n\n✍🏻 Yunwen Liu\n\nYunwen Liu is a cryptographer at Cryptape. She completed her Ph.D at COSIC, KU Leuven. She published 20+ research papers in venues including Eurocrypt and Journal of Cryptology. She has served on the program committees of Eurocrypt 2022 and ToSC 2022/2023.",
       "url": "/docs/res/payment-channel",
       "source": "docs/res/payment-channel.mdx"
     },
     {
-      "id": "chunk-942",
+      "id": "chunk-944",
       "title": "Pulse 01",
       "content": "Hey Builders on Fiber,\n\nWhile development on the protocol level continues to push forward (check the latest [**Devlog**](https://docs.fiber.world/blog/d/1994384f43a636e5) for the technical deep-dive), the ecosystem is rapidly evolving.\n\nWe’re kicking off **Pulse**—a bi-weekly series to highlight what’s happening across the network. It’s been an exciting few weeks as we watch community projects move from initial proposals to successful milestone deliveries.\n\nHere’s a look at recent progress:\n\n### Fiber Link: Keep Moving in the Final Stage",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-943",
+      "id": "chunk-945",
       "title": "Pulse 01",
       "content": "**Fiber Link** is an open-source payment layer that enables instant, low-fee tipping and micropayments inside online communities. Built on the Fiber Network, it abstracts away operational complexity by providing an always-online \"hub\" node and a lightweight account/ledger service.",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-944",
+      "id": "chunk-946",
       "title": "Pulse 01",
       "content": "**Status Update:** The contributors recently completed Milestone 2 (Discourse plugin + End-to-end tipping) and confirmed receipt of their first grant payout from the CKB Community Fund. To ensure better accessibility for the community, the project has transitioned its documentation and submission materials to a new [self-hosted repository](https://share.random-walk.co.jp/d/2dfc925ff48e48d1836c/), which will serve as the permanent home for all subsequent milestone artifacts.\nThey are now charging into Milestone 3, focusing on withdrawals, full documentation, and a mainnet-ready release.",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-945",
+      "id": "chunk-947",
       "title": "Pulse 01",
       "content": "- **Check it out:** [GitHub Repo](https://github.com/Keith-CY/fiber-link/)\n- **Discussion**: [Nervos Talk Thread](https://talk.nervos.org/t/dis-fiber-link-a-ckb-fiber-based-pay-layer-tipping-micropayments-for-communities/9845/24)\n- **Support:** Backed by the **CKB Community Fund**\n\n### Fiber Audio Player: Self-Hosting a Micropayment-Based Podcast Service\n\n**Fiber Audio Player** is a self-hosted podcast service that implements per second micropayments directly on user-controlled hardware. It is designed to run on consumer-grade hardware, allowing creators to distribute content and collect revenue without centralized intermediaries.\n\nHighlights:",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-946",
+      "id": "chunk-948",
       "title": "Pulse 01",
       "content": "- **Infrastructure**: Runs on a home PC using Cloudflare Tunnel to expose the service without a public IP.\n- **Payments Layer**: Integrates a Fiber node for real-time, multi-hop payment channels.\n- **Media Stack**: Built with Next.js, Hono, and SQLite, using FFmpeg for HLS encrypted streaming.\n- **Operations**: Managed via OpenClaw, a Discord-integrated AI agent that executes tasks through a custom CLI.\n\n**Status Update:** The project is a functional prototype currently running on the Fiber testnet. The developer is refining the system for a future Mainnet release.",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-947",
+      "id": "chunk-949",
       "title": "Pulse 01",
       "content": "- **Check it out:** [GitHub Repo](https://fiber-audio-player.vercel.app/)\n- **Discussion:** [Nervos Talk Thread](https://talk.nervos.org/t/make-self-host-great-again-how-i-use-fiber-and-openclaw-to-run-a-podcast-payment-service/10073/4)\n\n### Fiber-Pay: Powering the AI Economy\n\n**Fiber-pay** is a CLI tool designed to allow AI agents to interact directly with the Fiber Network. It automates the process of running a node: handling binary downloads, configuration, and peer connections, enabling agents to open channels and execute payments via terminal commands. The tool outputs data in JSON format, specifically designed for machine parsing and autonomous error handling.\n\n**Status Update:** The latest v0.1.0 release targets FNN version 0.7.1 and is optimized for the testnet. Key features include:",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-948",
+      "id": "chunk-950",
       "title": "Pulse 01",
       "content": "- **Daemon Mode:** Start nodes in the background for persistent operation.\n- **Profile Support:** Run and manage multiple independent nodes on a single machine using unique RPC and P2P ports.\n- **Wallet Integration:** Quick commands for CKB balance retrieval and generating funding address QR codes.\n- **Skill Integration:** Compatibility with the OpenClaw framework via a dedicated skill file.\n\n- **Check it out:** [GitHub Repo](https://github.com/RetricSu/fiber-pay)\n- **Discussion:** [Nervos Talk Thread](https://talk.nervos.org/t/fiber-pay-an-ai-friendly-cli-for-fiber-network/9974/4)\n\n### Fiber Node Installer: Easier Node Setup for Windows and Linux",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-949",
+      "id": "chunk-951",
       "title": "Pulse 01",
       "content": "**Fiber Node Installer** is designed to automate Fiber node deployment on Windows and Ubuntu/Debian systems. It simplifies the technical overhead of joining the CKB/Fiber payment ecosystem by handling firewall configuration, background service setup, and optional weekly auto-updates. The tool supports both testnet and mainnet environments, allowing users to transition from a sandbox setup to live funds within a standardized installation flow.\n\nThe installer includes an optional private web dashboard for managing channels, peers, and network visibility. Security is handled by keeping the node RPC and dashboard off the public internet, using an SSH tunnel for Linux access.",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-950",
+      "id": "chunk-952",
       "title": "Pulse 01",
       "content": "The project is seeking community feedback on the first-time setup experience and dashboard UX to further reduce friction for new node operators and builders.\n\n- **Check it out:** [GitHub Repo](https://github.com/tecmeup123/fiber-node-installer)\n- **Discussion:** [Nervos Talk Thread](https://talk.nervos.org/t/fiber-node-installer-easier-fiber-node-setup-for-windows-and-linux-local-or-remote/10071)\n\n### Fiber-Checkout: Stripe Experience on CKB\n\nIntegrating payments shouldn't be a bottleneck. **Fiber-checkout** is a proposed React component library and hooks package designed to simplify the integration of Fiber Network payments into web applications. Developed by SalmanDev, the project aims to replace manual JSON-RPC calls and hex encoding with a \"Stripe-style\" developer experience.",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-951",
+      "id": "chunk-953",
       "title": "Pulse 01",
       "content": "By wrapping the recently released `@nervosnetwork/fiber-js`, the library provides ready-made user interface elements that automatically create invoices, display QR codes, and check the payment status every few seconds. This allows developers to accept CKB, RUSD, and SEAL payments without having to write the underlying logic themselves.\n\n**Status Update:** The proposal is currently “Pending” in the Spark Program. Following committee feedback regarding long-term maintenance and the details of the deliverables, SalmanDev has replied, detailing the delivery and future support plan.\n\n- **Discussion:** [Nervos Talk Thread](https://talk.nervos.org/t/spark-program-fiber-checkout-a-stripe-style-react-payment-library-for-fiber-network/10045/5)",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-952",
+      "id": "chunk-954",
       "title": "Pulse 01",
       "content": "### Nervos Brain: An Agentic RAG Hub for CKB & Fiber Developers\n\n**Nervos Brain** is building a proactive intelligent engine to onboard and support developers across the Nervos ecosystem. It uses a dedicated MCP Server to read the latest RFCs, codebase docs, and bug records to directly assist with code. It also features a multi-step reasoning agentic RAG for generating tutorials. For instance, if you wanna know the prerequisites and steps to open a channel in the Fiber Network, it will give you a guide generated from synthesizing multiple available sources.\n\n**Funding Update:** The project successfully secured **Spark Program** funding, and their first milestone ($400 USDI) has already been disbursed.",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-953",
+      "id": "chunk-955",
       "title": "Pulse 01",
       "content": "- **Discussion:** [Nervos Talk Thread](https://talk.nervos.org/t/spark-program-nervos-brain-a-global-developer-onboarding-engine-and-cross-language-hub-powered-by-agentic-rag/9995)\n\n### Claw Hackathon: CKB AI Agent Hackathon\n\nOpen until 25th March (12:00 UTC), the **Claw Hackathon** is calling all builders to capitalize on the AI agent revolution. CKB is uniquely positioned for this: its lock scripts provide strict spending boundaries so autonomous agents can't drain funds, while the RISC-V based CKB-VM offers plug-and-play flexibility without cryptographic precompiles constraints. Combine that with high-frequency, low-cost micropayments on Fiber Network, and you have the perfect sandbox for the agentic economy.",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-954",
+      "id": "chunk-956",
       "title": "Pulse 01",
       "content": "- Details: [Forum link](https://talk.nervos.org/t/claw-order-ckb-ai-agent-hackathon-announcement/10038)\n\n### Got an idea? Get it moving.\n\nFiber Network is more than a payment channel protocol. It's a community-driven ecosystem with the resources to back its builders. If you have a project idea that enhances the network, the Nervos ecosystem offers multiple paths for support:",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-955",
+      "id": "chunk-957",
       "title": "Pulse 01",
       "content": "- [**Spark Program**](https://www.notion.so/1f424205dae080faad8de72a438d576f?pvs=21): A fast-track initiative for prototyping. It provides up to $2,000 in rapid funding to help developers turn early-stage ideas into verifiable MVPs within 1–2 months.\n- [**CKB Community Fund**](https://talk.nervos.org/t/ckb-community-fund-dao-rules-and-process/6874): A community-driven DAO providing grants for a wide range of ecosystem contributions, from core code development to content production and event organizing.\n\nDon't let a great idea stay stuck in your head. Whether you’re building a small utility or a complex platform, reach out to these programs or drop a post on the [Nervos Talk forum](https://talk.nervos.org/). We’d love to see your first milestone payout in the next update!",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-956",
+      "id": "chunk-958",
       "title": "Pulse 01",
       "content": "Have fun building! 🏗️\n\nFiber Devs",
       "url": "/docs/pulse/issue-01",
       "source": "pulse/issue-01.md"
     },
     {
-      "id": "chunk-957",
+      "id": "chunk-959",
       "title": "Pulse 02",
       "content": "*The most exciting work happens when builders take the lead.*\n\nThis bi-weekly updates are a dedicated look at community-driven innovations coming directly from the people building on the ground. Instead of waiting for a roadmap, they are identifying gaps and fixing them through their own initiative, shipping the tools that move the entire ecosystem forward.\n\nHere is what’s fresh from the community:\n\n### Fiber-Checkout: Spark Program Grant Awarded\n\n**Status Update**: Fiber checkout has been granted $1,000 USD as a new Spark Program recipient. The Spark Program Committee approved the project following supplementary revisions.",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-958",
+      "id": "chunk-960",
       "title": "Pulse 02",
       "content": "This tool provides a React component library and hooks for developers. It simplifies integrating Fiber Network payments into web applications. The project fills a critical gap in the current ecosystem's front-end payment tooling.\n\n- **Check it out**: [Forum Link](https://talk.nervos.org/t/spark-program-fiber-checkout-a-stripe-style-react-payment-library-for-fiber-network/10045/7)\n- **Support**: Backed by the Spark Program\n\n### Fiber Link: Milestone 3 Admin Scope Complete\n\nFiber Link is an open-source payment layer enabling instant, low-fee tipping and micropayments built on Fiber Network.",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-959",
+      "id": "chunk-961",
       "title": "Pulse 02",
       "content": "**Status Update:** Fiber link wrapped up the Admin controls scope and reached Milestone 3 major goals. They added a monitoring summary and global rate limiting. New tools for backup and restoration are now live. All security hardening is merged. The platform is now stable and ready for the next phase.\n\n**Check it out**: [forum link](https://talk.nervos.org/t/dis-fiber-link-a-ckb-fiber-based-pay-layer-tipping-micropayments-for-communities/9845/26?u=sss_is_me)\n\n**Support**: Backed by the CKB Community Fund.\n\n### Nervos Brain Update: From Scaffold to Execution",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-960",
+      "id": "chunk-962",
       "title": "Pulse 02",
       "content": "**Status Update**: **Nervos Brain** has transitioned from a process demonstration to a minimum execution graph. This week, the team successfully built the LangGraph core engine and implemented dynamic routing, allowing the AI to make real-time decisions instead of following a fixed sequence. The system can now evaluate whether a query needs more information and orchestrate multi-tool invocations to gather evidence.",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-961",
+      "id": "chunk-963",
       "title": "Pulse 02",
       "content": "On the infrastructure side, the team completed the foundational work for database integration. This includes setting up the data structures for memory and state persistence, which are essential for a closed-loop retrieval system. Next week, the focus shifts from the execution framework to the data pipeline, specifically acquiring real-world corpora and building out the vector database for ingestion.\n\nNervos Brain aims to be a proactive intelligent engine, integrated into Discord, Telegram, and forums, onboarding developers across the Nervos ecosystem.\n\n- **Check it out**: [Forum Link](https://talk.nervos.org/t/spark-program-nervos-brain-a-global-developer-onboarding-engine-and-cross-language-hub-powered-by-agentic-rag/9995/19?u=sss_is_me)\n- **Support**: Backed by the Spark Program",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-962",
+      "id": "chunk-964",
       "title": "Pulse 02",
       "content": "### Spark Program Q1 2026: The Rise of Fiber’s Access Layer\n\nThe Spark Program's [Q1 report](https://talk.nervos.org/t/spark-program-q1-2026-what-builders-are-telling-us/10114) highlights Fiber as a primary driver of current ecosystem growth, noting that its protocol layer is now sufficiently mature for builders to focus on the missing access layer. Key projects addressing this include:\n\n- **fiber-checkout:** A React component library for web developers.\n- **Fiber Link:** A tipping plugin for off-chain settlement.\n- **Blackbox:** Physical POS terminal hardware.",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-963",
+      "id": "chunk-965",
       "title": "Pulse 02",
       "content": "Operationally, the report notes that Fiber-related projects are successfully moving through the funding pipeline. **Fiber Link** is cited as a prime example of the Spark to DAO transition, having graduated from the Spark Program to the Community Fund DAO for full milestone execution. Additionally, **fiber-checkout** was officially approved this quarter with a $1,000 grant to continue simplifying payment integrations for the broader developer community.",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-964",
+      "id": "chunk-966",
       "title": "Pulse 02",
       "content": "The Nervos/Fiber community isn't waiting for a perfect moment to start. Essential tools are being built right now by people who saw a missing feature and decided to ship a solution. Whether focused on payments, developer experience, or infrastructure, every project brings unique value to the network. If you've got a repository started or a project in the works, there's a seat at the table.\n\nThe ecosystem is set up to back you:",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-965",
+      "id": "chunk-967",
       "title": "Pulse 02",
       "content": "- [**Spark Program**](https://www.notion.so/1f424205dae080faad8de72a438d576f?pvs=21): A fast-track initiative for early ideas—up to $2,000 USD to get from concept to a working MVP in ~1–2 months\n- [**CKB Community Fund**](https://talk.nervos.org/t/ckb-community-fund-dao-rules-and-process/6874): A boader, community-driven DAO providing grants for a wide range of Nervos contributions, from code development to content production and event organizing.\n\nDon't let a great idea stay stuck in your head, post your draft on the [Nervos Talk forum](https://talk.nervos.org/). We’d love to see your first milestone payout in the next update!\n\n**Enjoy building!**\n\n**Fiber Devs**",
       "url": "/docs/pulse/issue-02",
       "source": "pulse/issue-02.md"
     },
     {
-      "id": "chunk-966",
+      "id": "chunk-968",
       "title": "Pulse 03",
       "content": "**The most exciting work happens when builders take the lead.**\n\nOver the past two weeks, the hackathon has brought in a new wave of projects. We’ve seen more builders step in and try things out.\n\nBeyond the hackathon, projects continue to evolve and move forward.\n\n### Claw & Order Hackathon: When AI Agents Meet Fiber\n\nThe [Claw & Order: CKB AI Agent Hackathon](https://talk.nervos.org/t/claw-order-hackathon-roundup/10154) (Mar 11–25) recently wrapped up. 22 projects explored a simple but ambitious idea: **What happens when AI agents can own wallets and make payments natively?**",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-967",
+      "id": "chunk-969",
       "title": "Pulse 03",
       "content": "By combining CKB’s cell model with Fiber’s micropayment capabilities, our community built agents that can coordinate, transact, and operate autonomously. Judging is still in progress, but we did’t want to wait to highlight what’s been built on Fiber:\n\n**Agent Coordination, Execution, and Safety**\n\n- [**Omniflow**](https://github.com/FadhilMulinya/Omniflow): Visual drag-and-drop builder to create AI agents and automate CKB/Fiber workflows without writing complex code.\n- [**CKB Alpha Agent**](https://github.com/JouahriAli/Ckb-alpha-agent): Oracle agent providing statistical token analysis; users pay via Fiber micropayments for verifiable on-chain proofs.\n\n**Payment and Commerce Solutions:**",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-968",
+      "id": "chunk-970",
       "title": "Pulse 03",
       "content": "- [**Fiber-pilot**](https://github.com/RaheemJnr/fiber-pilot): AI agent for Fiber node management using a 17-tool MCP server to automate channel and liquidity operations.\n- [**Fiber Agent Pay**](https://github.com/Jeremicarose/FiberAgentPay): SDK and demo showing a self-sustaining agent economy where bots buy/sell services autonomously within CKB lock script limits.\n- [**Fiber402**](https://github.com/David-Pjs/fiber402): Implementation of HTTP 402 for “pay-per-use” API access, enabling AI agents to pay for data instantly via Fiber.\n\n**Gaming, Social, and Local Tools:**",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-969",
+      "id": "chunk-971",
       "title": "Pulse 03",
       "content": "- [**FiberQuest**](https://github.com/toastmanAu/fiberquest): Tournament agent for retro games that polls RAM in real-time to score players and pay winners autonomously via Fiber.\n- [**SliceStream**](https://github.com/qrwd/SliceStream): Desktop-first local tool for CKB/Fiber workflows, providing a transparent, “fail-closed” environment for non-custodial execution.\n\nWe’ve seen a real burst of creativity here—especially from developers relatively new to CKB through the CKBuilders program!\n\nAll submissions are open-sourced, meaning these aren’t just hackathon demos, but are starting points others can fork and push further.\n\nWe’re looking forward to the judges’ feedback. But regardless of rankings, it’s already clear: this is the kind of experimentation that moves the ecosystem forward.",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-970",
+      "id": "chunk-972",
       "title": "Pulse 03",
       "content": "### Fiber Checkout is Live: Add Fiber Payment to Web Apps\n\nA React component library that simplifies integrating Fiber payments into web applications, **Fiber Checkout** is now complete and published.\n\nWeb developers can now add a full Fiber payment flow to React or Next.js apps with a single component. Drop it in and you get: invoice generation, QR code rendering, payment status polling, expiry detection, and error handling out of the box. No Rust. No complex RPC knowledge. Just install and go. The full flow from npm installation, to component rendering and payment confirmation on testnet—can be done in under 10 minutes.",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-971",
+      "id": "chunk-973",
       "title": "Pulse 03",
       "content": "- **Check it out**: [Forum Link](https://talk.nervos.org/t/spark-program-fiber-checkout-a-stripe-style-react-payment-library-for-fiber-network/10045/15)\n- **npm**: https://www.npmjs.com/package/fiber-checkout\n- **GitHub Repo**: https://github.com/salmansarwarr/Fiber-checkout\n- Demo: https://fiber-checkout.vercel.app/\n- Demo video: https://www.youtube.com/watch?v=Jexw2F-P7fM\n- **Support**: Spark Program\n\n### Fiber Link: Public Testing Now Open\n\nThe open-source micropayment tipping layer—**Fiber Link**—is moving into broader public testing.\n\nCurrent Status:\n\n- Creator flow is live (receive tips, check balance, withdraw)\n- Reader-side tipping depends on shared node liquidity (still evolving)",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-972",
+      "id": "chunk-974",
       "title": "Pulse 03",
       "content": "The team is actively accepting demo requests if you want early access: https://fiberlink.me/en/request-demo.\n\n- **Check it out**: [Forum Link](https://talk.nervos.org/t/dis-fiber-link-a-ckb-fiber-based-pay-layer-tipping-micropayments-for-communities/9845/29)\n- **Support**: CKB Community Fund\n\n### Fiber Audio Player: Pay-Per-Second, Now in the Browser\n\nThe self-hosted podcast platform with per-second micropayments—**Fiber Audio Player**—now supports Fiber WASM node with a passkey experience:\n\n- Runs a Fiber node directly in the browser (WASM)\n- Uses passkeys (WebAuthn PRF) for key management\n- No standalone node required\n\nSo yes, you can now *pay per second* for audio, directly from the browser, with full control over your keys.",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-973",
+      "id": "chunk-975",
       "title": "Pulse 03",
       "content": "- **Check it out**: [Forum Link](https://talk.nervos.org/t/make-self-host-great-again-how-i-use-fiber-and-openclaw-to-run-a-podcast-payment-service/10073/6)\n- **Demo**: https://fiber-audio-player.vercel.app/\n\n### Fiber Pay (v0.2.1): AI-Friendly Payments Getting Simpler\n\nAs a tool that enables AI to interact with the Fiber Network, Fiber Pay continues to move toward a more developer-friendly integration experience.\n\nLatest release (v0.2.1):\n\n- Introduced the Fiber WASM + passkey component in @fiber-pay/sdk\n\nDevelopers can now integrate Fiber payments directly in the browser, with Passkey support built in. No standalone node needed. It’s a much simpler setup—and feels closer to a Stripe-like integration.",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-974",
+      "id": "chunk-976",
       "title": "Pulse 03",
       "content": "- Check it out: [Forum Link](https://talk.nervos.org/t/fiber-pay-an-ai-friendly-cli-for-fiber-network/9974/7)\n- GitHub Repo: https://github.com/RetricSu/fiber-pay\n\nThe Nervos and Fiber community isn’t waiting for a perfect moment to start—and neither should you. Whether you’re interested in AI agents, micropayment APIs, or user-facing apps, you don't have to build in a vacuum. We’re here to back you:\n\n- **Spark Program:** Perfect for early-stage ideas. Get up to **$2,000 USD** to take your concept to a working MVP in 1–2 months.\n- **CKB Community Fund**: A community-driven DAO offering grants for development, content, and broader ecosystem initiatives.",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-975",
+      "id": "chunk-977",
       "title": "Pulse 03",
       "content": "If you’ve got something in progress—even an early draft—share it on the Nervos Talk forum. We care about the problems you are solving, and we’d love to feature your progress in the next Fiber Pulse.\n\n**Enjoy building!**\n\nFiber Devs",
       "url": "/docs/pulse/issue-03",
       "source": "pulse/issue-03.md"
     },
     {
-      "id": "chunk-976",
+      "id": "chunk-978",
       "title": "Pulse 04",
       "content": "*The most exciting work happens when builders take the lead.*\n\nAhead of Bitcoin 2026, here’s a quick snapshot of what’s been happening across community projects building with Fiber.\n\n### Fiber-Checkout: Stripe-Style React Payment Library Now Completed\n\nThe fiber-checkout project has submitted its [completion report](https://talk.nervos.org/t/spark-program-fiber-checkout-a-stripe-style-react-payment-library-for-fiber-network/10045), marking the delivery of a new payment tool for Fiber Network. \n\nBuilt for React and Next.js, it wraps Fiber payment flows into a simple checkout component, replacing complex manual steps with a ready-to-use checkout component. \n\n**What shipped:**\n\n- npm package\n- live demo\n- documentation\n- tested integrations",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-977",
+      "id": "chunk-979",
       "title": "Pulse 04",
       "content": "It was delivered within the planned 4-week timeline and is now ready for developers to plug into real apps.\n\n- **Support**: Spark Program\n\n### Fiber Link: Testnet Keeps Running Smoothly\n\nThe Fiber Link team shared its latest [Milestone 3 update](https://talk.nervos.org/t/dis-fiber-link-a-ckb-fiber-based-pay-layer-tipping-micropayments-for-communities/9845/30). The long-running public Testnet demo remains stable and operational, with:\n\n- 109 successful tips\n- 32 successful withdrawals\n- 1 channel rotation for replenishing liquidity.\n\nNext up: improved operator-friendly deployment and plugin installation guides to support future handoff and independent operation.\n\n- Support: CKB Community Fund\n\n### Dular: Mobile Money Stablecoin Wallet on Fiber",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-978",
+      "id": "chunk-980",
       "title": "Pulse 04",
       "content": "Dular is building a stablecoin wallet designed for users in Africa, Southeast Asia, and Latin America, where mobile money is already the default payment experience. With Dular, instead of complex crypto wallets, users can:\n\n- Send funds via phone numbers\n- Deposit and withdraw through services like M-Pesa\n- Access wallets via USSD on feature phones, without internet\n\nDular uses Fiber’s payment channel network to enables near-instant transfers with extremely low fees, while supporting native stablecoins and future local currency assets.",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-979",
+      "id": "chunk-981",
       "title": "Pulse 04",
       "content": "- **Status**: The project is currently updating its application based on reviewer feedback in order to proceed to formal committee review.\n- **Check it out**: [Forum link](https://talk.nervos.org/t/spark-program-dular/10212)\n- **Application for**: Spark Programme\n\n### Backr: Creator Memberships Powered by Fiber\n\nBackr is a creator platform that enables paid posts, subscriptions, and community interaction through wallet-based identities instead of traditional accounts. \n\n**How payments work:**\n\n- Subscriptions and renewals are paid via Fiber Network\n- Creators selling memberships run their Fiber Nodes and configure its JSON-RPC endpoint in the app\n- Backr coordinates Fiber invoice creation and payment handling on the server side, keeping the browser out of the payment flow.",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-980",
+      "id": "chunk-982",
       "title": "Pulse 04",
       "content": "This keeps payments non-custodial while giving creators full control over their setup.\n\n- Check it out: [Forum link](https://talk.nervos.org/t/introducing-backr-creator-memberships-and-paid-content-on-nervos-ckb/10191)\n\n### LUME: Explores a Programmable Yield Layer\n\nA community proposal LUME proposes a programmable yield layer built on top of RGB++, aiming to connect Bitcoin and CKB through yield, liquidity, and network participation \n\n**The idea:**\n\n- Users lock assets like CKB into a reserve-backed system\n- Earn yield based on network activity and fees\n- Build liquidity between BTC and CKB\n\nIn this design, Fiber Network would serve as a bridge and liquidity layer, connecting flows across systems.",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-981",
+      "id": "chunk-983",
       "title": "Pulse 04",
       "content": "- Check it out: [Forum link](https://talk.nervos.org/t/powerful-asset-complenting-ckb-and-btc-ai-generated-idea/10170)\n\n### Idea Feasibility Check: AI Workflow Monetization\n\nCreators of open-source AI image/video generation often face a recurring issue: they build high-quality workflows, where the key values lies in a few critical parameters (e.g. CFG, steps, shift). These are easy to copy and redistribute without permission.\n\nThis idea explores a way to monetize AI workflow (especially ComfyUI) by separating its key parameters:\n\n**Concept:**\n\n- Main workflow stays open-source and runs locally\n- Key parameters (like CFG, steps, tuning values) are encrypted and stored cheaply on CKB\n- Fiber handles parameter retrieval and delivery back to the users",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-982",
+      "id": "chunk-984",
       "title": "Pulse 04",
       "content": "This enables a pay-per-use or pay-per-generation monetization model for creators while preserving an open ecosystem.\n\n- Check it out: [Forum link](https://talk.nervos.org/t/product-idea-hiding-monetizing-core-ai-workflow-parameters-on-ckb-fiber-feasibility-check-ckb-fiber-ai/10175)\n\nThe ecosystem is still early, and most of what matters is happening in public — in forum posts, prototypes, and half-finished ideas that slowly turn into real products.\n\nIf you’re building something, here’s how we can support you:\n\n- **Spark Program**: up to $2,000 for early MVPs (1–2 months)\n- **CKB Community Fund**: DAO grants for broader ecosystem work",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-983",
+      "id": "chunk-985",
       "title": "Pulse 04",
       "content": "Share your progress on [Nervos Talk](https://talk.nervos.org/), even if it’s just a rough idea. That’s usually where the interesting things start. We’ll likely feature more of these in the next Fiber Pulse.",
       "url": "/docs/pulse/issue-04",
       "source": "pulse/issue-04.md"
     },
     {
-      "id": "chunk-984",
+      "id": "chunk-986",
       "title": "Pulse 05",
       "content": "*The most exciting work happens when builders take the lead.*\n\n### Fiber Link: From Prototype to Product-Ready\n\n**Fiber Link** has published its latest product delivery report, marking its transition from an engineering prototype toward a product-ready, deployable release.\n\nBuilt as an open-source tipping layer for online communities, Fiber Link lets users tip posts or replies directly from familiar forum interfaces (starting with [Discourse](https://demo.fiberlink.me/latest)), without requiring members to run their own Fiber nodes. \n\nThis milestone includes a [ video demo](https://youtu.be/xdPp42APukw) with comprehensive documentation for administrators and operators to deploy the service.",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-985",
+      "id": "chunk-987",
       "title": "Pulse 05",
       "content": "- **Product Overview**: [GitHub Repo](https://github.com/Keith-CY/fiber-link/blob/main/README.md)\n- **Check it out**: [Forum link](https://talk.nervos.org/t/dis-fiber-link-a-ckb-fiber-based-pay-layer-tipping-micropayments-for-communities/9845/34)\n- **Support**: CKB Community Fund\n\n### Fiber-Pay v0.2.5: Simplified Connect Flow & New Demos\n\n**Fiber Pay** is a toolkit that allows AI agents to manage Fiber Network operations like opening channels and making payments. Its latest release  introduces `ConnectButton`, a simplified way for frontend apps to connect to a Fiber browser node using passkey or password authentication with minimal setup.",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-986",
+      "id": "chunk-988",
       "title": "Pulse 05",
       "content": "This update also includes stability fixes for `useFiberNode` under React `StrictMode`, a refreshed [browser-wallet demo](https://github.com/RetricSu/fiber-pay/tree/master/apps/browser-wallet) with the new connect flow, and a [quick-card demo](https://github.com/RetricSu/fiber-pay/tree/master/apps/react-quick-card) showing payment integration and UI customization.\n\n- **v0.2.5** [Release note](https://github.com/RetricSu/fiber-pay/releases/tag/v0.2.1)\n- **Check it out:** [Forum Link](**https://talk.nervos.org/t/fiber-pay-an-ai-friendly-cli-for-fiber-network/9974/8?u=sss_is_me**)**\n\n### Decentralized AI Agent Calling Experiment via Fiber",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-987",
+      "id": "chunk-989",
       "title": "Pulse 05",
       "content": "Built on top of the latest Fiber-Pay release, this experiment explores a **decentralized AI Agent calling platform**. Users can invoke agents running on remote hardware from their browsers, with peer-to-peer payments, similar in experience to cloud-based agent services.\n\nKey aspects include:",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-988",
+      "id": "chunk-990",
       "title": "Pulse 05",
       "content": "- **Instant Micropayments:** L402-style payment flow currently with per-call pricing (currently 0.1 CKB on testnet) via Fiber.\n- **Decentralized design:** Agents are hosted by anonymous operators, reducing reliance on centralized APIs and allowing users to access the latest agent capabilities by updating their local clients.\n- **Technical Implementation:** Focuses on containerized agent runtime for isolation, the `acpx` library to support multiple agent types, and environment variable control to prevent sensitive API key leakage.\n\n- **Try the Demo**: https://calling-agent-kappa.vercel.app/\n- **Check it out**: [Forum link](https://talk.nervos.org/t/a-paid-ai-agent-calling-experiment-via-fiber/10229)\n\n### Spark Proposal: Dular—Mobile Money Stablecoin Wallet",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-989",
+      "id": "chunk-991",
       "title": "Pulse 05",
       "content": "**Dular** is a stablecoin wallet designed to bridge Fiber with the mobile money ecosystem. It replaces hex addresses with phone number identities and supports USSD access for feature phones. It leverages Fiber’s low-fee, native multi-asset channels to enable instant payments, with integrated [M-Pesa](https://en.wikipedia.org/wiki/M-Pesa) on/off ramps.\n\n- **Status**: Additional evidence and documentation submitted; currently under committee review.\n- **Check it out**: [Forum link](https://talk.nervos.org/t/spark-program-dular/10212/4)\n\n### Upcoming Reddit AMA on Fiber\n\nThe latest Nervos AMA focuses on the Fiber Network! Join us to chat with DevRel engineer Retric about his recent experiments with paywalled applications, including the Fiber Audio Player and L402 blog prototype.",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-990",
+      "id": "chunk-992",
       "title": "Pulse 05",
       "content": "Join the discussion or drop questions in advance [here](https://www.reddit.com/r/NervosNetwork/comments/1t3bc8s/the_fiber_network_ama/) before **May 12th at 11 GMT**!\n\n### Got an idea? Let’s see it take shape.\n\nFiber Network is a community-driven ecosystem with real support behind its builders. If you’re thinking about building something, here is how we can help:",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-991",
+      "id": "chunk-993",
       "title": "Pulse 05",
       "content": "- [**Spark Program**](https://www.notion.so/1f424205dae080faad8de72a438d576f?pvs=21): A fast-track path for early prototypes, offering up to **$2,000** in funding to help turn ideas into working MVPs within 1–2 months.\n- [**CKB Community Fund**](https://talk.nervos.org/t/ckb-community-fund-dao-rules-and-process/6874): A DAO-backed grant program supporting a wide range of ecosystem work, from core development to tools, content, and community initiatives.\n\nShare your idea on the [Nervos Talk](https://talk.nervos.org/) forum and reach out to the programs above. We’d  love to see what you build show up in our next update!\n\nKeep building 🏗️",
       "url": "/docs/pulse/issue-05",
       "source": "pulse/issue-05.md"
     },
     {
-      "id": "chunk-992",
+      "id": "chunk-994",
       "title": "Pulse 06",
       "content": "*The most exciting work happens when builders take the lead.*\n\n### Grant Approved: Dular Connects Fiber to Mobile Money Infrastructure\n\nThe Spark Program Committee has approved a $2,000 USD grant (funded via 1,408,451 CKB) for **Dular**, a stablecoin wallet designed to bridge CKB's Fiber Network with traditional mobile money rails like M-Pesa. Designed for practical accessibility, Dular uses phone numbers as identities and features USSD (Unstructured Supplementary Service Data) support for feature phones. This allows users to transact with stablecoins without navigating complex cryptographic addresses.",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-993",
+      "id": "chunk-995",
       "title": "Pulse 06",
       "content": "The approval follows a rigorous review process aligned with Spark 2026's technical focus on Fiber Network and UDT-based (User Defined Token) payments. The committee noted that Dular brings Fiber's capabilities into a practical, real-world retail payment scenario. The project's milestones include a 30-seed-user pilot and a structured user feedback report, matching Spark's requirement for verifiable deliverables.\n\nWelcome to the ecosystem, Dular! 🎉\n\n- **Supported by**: The Spark Program\n- **Check it out**: [Forum Link](https://talk.nervos.org/t/spark-program-dular/10212/5)\n\n### Scryve Reads: A Live Demo of Pay-As-You-Read Content Streaming\n\n**Scryve Reads** is a digital reading platform testing a micro-payment alternative to traditional monthly subscriptions and sign-up walls.",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-994",
+      "id": "chunk-996",
       "title": "Pulse 06",
       "content": "Built on the community-developed [`fiber-pay` SDK](https://talk.nervos.org/t/fiber-pay-an-ai-friendly-cli-for-fiber-network/9974/7), the project combines a JoyID passkey wallet running directly inside the browser as a light node to set up a direct payment link for readers. \n\nInstead of buying an entire article upfront, users read for free until they reach a paywall. As they scroll past it, the browser node automatically sends a micro-payment to unlock the next section. Writers can publish essays, set granular pricing per section, track realtime earnings, and withdraw their revenue to their personal wallets instantly.",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-995",
+      "id": "chunk-997",
       "title": "Pulse 06",
       "content": "- Check it out: [Forum Link](https://talk.nervos.org/t/scryve-reads-a-demo-on-pay-as-you-read-with-fiber/10304)\n- Dive deeper: Read the Scryve team's take on the creator economy, micropayment, and pay-per-read models: *[Are Paywalls Killing the Creator Economy - or Saving It?](https://talk.nervos.org/t/are-paywalls-killing-the-creator-economy-or-saving-it/10299)*\n\n### Fiber Desktop: Simplifying Local Node Management\n\nFiber Desktop is a community-developed graphical interface that wraps the official Fiber Network Node, removing the need for a virtual private server (VPS) or heavy command-line setups. It allows developers and power users to run an official Fiber node locally on their own hardware. \n\nFiber Desktop includes:",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-996",
+      "id": "chunk-998",
       "title": "Pulse 06",
       "content": "- **Guided setup:** walks you through setup in order (network, data folder, configuration, and key material placement).\n- **Dashboard:** the one place for starting/stopping the node, viewing logs, and interacting with the network.\n- **Vault assistant:** stores the node's encryption password in your operating system's built-in secure storage (keychain or credential manager) instead of saving it in plaintext files.",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-997",
+      "id": "chunk-999",
       "title": "Pulse 06",
       "content": "This tool significantly improves the onboarding flow for testing and development. By replacing long terminal sequences with intuitive UI flows for connecting to public relays, opening channels, and generating invoices, it bridges the gap between core infrastructure and application developers. It is now much easier to quickly deploy a self-custodial node on a local machine and start interacting with the network topology right away.\n\n- Check it out: [Forum Link](https://talk.nervos.org/t/fiber-desktop-run-fiber-fnn-on-your-laptop-without-the-public-node-headache/10247)\n\n### Discussion | Mapping the LSP Link Between Bitcoin Lightning and Fiber",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-998",
+      "id": "chunk-1000",
       "title": "Pulse 06",
       "content": "A community member recently mapped out how Fiber can seamlessly interact with the Bitcoin Lightning Network using LSPs (Lightning Service Providers). The core idea is that LSPs are essential for Fiber, not just to streamline wallet onboarding, but to allow BTC liquidity to flow between both networks.\nThe author points out that by using LNURL and LSPs, developers can build swap mechanics between Fiber wallets and Lightning wallets, allowing users to move BTC into the Fiber network imperceptibly. When you combine that flow with Fiber's on-chain programmability and WASM runtime, you get a \"bridgeless\" BTC → CKB cross-chain where native BTC can interact directly with CKB dApps. The author emphasizes that this achieves Lightning-level speed and execution rather than relying on heavy, traditional sidechain architectures.",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-999",
+      "id": "chunk-1001",
       "title": "Pulse 06",
       "content": "Commenting on the post, another builder pointed out that this infrastructure reinforces Fiber's natural fit for **pay-as-you-use services** and **streaming payments**, rather than replicating traditional everyday payment apps. In these ongoing service relationships, the channel model—with its specific approach to managing liquidity and node reachability—feels completely native, with LSPs handling reliability and adoption on top of a channel-driven user experience.\n\n- Join the conversation: [Forum Link](https://talk.nervos.org/t/fiber/10298)\n\n### Proposal: Fiber Payjoin Kit for Native, Collaborative Privacy\n\nILE Labs has proposed `fiber-payjoin-kit`, an open-source, asynchronous Rust library designed to bring collaborative Payjoin privacy natively to the Fiber Network.",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-1000",
+      "id": "chunk-1002",
       "title": "Pulse 06",
       "content": "Currently, when a payment channel opens, blockchain tracking tools assume all input cells belong entirely to the initiator, permanently linking the sender and receiver. This project solves that privacy leak by allowing both parties to contribute inputs to the channel-funding transaction. To an outside observer looking at the CKB L1 blockchain, the transaction mimics a standard multi-party coinjoin, making it mathematically difficult to tell who funded the channel or who is sending and receiving.\n\nThe team is porting this architecture from their existing open-source Bitcoin Lightning Network library (`lightning-payjoin-kit`), mapping the logic onto CKB's Cell model to deliver a developer CLI, along with comprehensive documentation and integration examples for wallet integration.",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-1001",
+      "id": "chunk-1003",
       "title": "Pulse 06",
       "content": "- Check it out: [Forum Link](https://talk.nervos.org/t/dis-fiber-payjoin-kit-collaborative-privacy-for-the-nervos-fiber-network/10296)\n\n### *Got an idea? Let’s Build It Together*\n\nFiber Network is a community-driven ecosystem, and we have real resources dedicated to backing builders. If you’ve been thinking about hacking on a tool, an application, or core infrastructure, we want to help you get it off the ground:",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-1002",
+      "id": "chunk-1004",
       "title": "Pulse 06",
       "content": "- [**Spark Program**](https://www.notion.so/1f424205dae080faad8de72a438d576f?pvs=21): A fast-track path for early prototypes, offering up to **$2,000** in funding to help turn ideas into working MVPs within 1–2 months.\n- [**CKB Community Fund**](https://talk.nervos.org/t/ckb-community-fund-dao-rules-and-process/6874): A DAO-backed grant program supporting a wide range of ecosystem work, from core development to tools, content, and community initiatives.\n\nShare your idea on the [**Nervos Talk**](https://talk.nervos.org/) forum and reach out to the programs above. We’d love to feature your project in our next update!\n\nKeep building 🏗️",
       "url": "/docs/pulse/issue-06",
       "source": "pulse/issue-06.md"
     },
     {
-      "id": "chunk-1003",
+      "id": "chunk-1005",
       "title": "Pulse 07",
       "content": "*The most exciting work happens when builders take the lead.*\n\n### Fiber Desktop: Shifting to the Seller Side & Active DAO Voting\n\n**Fiber Desktop**, a desktop application that makes running a local Fiber Network Node (FNN) effortless without a VPS, has laid out its next direction. The team is shifting focus to the **seller side** by adding a dedicated **Agents Tab**.",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1004",
+      "id": "chunk-1006",
       "title": "Pulse 07",
       "content": "This new feature allows merchants to seamlessly connect their online shops directly to the desktop application using a website URL and merchant credentials. As long as the app running locally, the local node handles invoice generation and transaction management automatically upon customer checkout—completely bypassing the need to manage a dedicated Fiber server. Additionally, the architecture supports multiple agents simultaneously, allowing a single desktop instance to manage payments for several independent storefronts at once.",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1005",
+      "id": "chunk-1007",
       "title": "Pulse 07",
       "content": "This milestone is tied to the [*Fiber Desktop v1 Ground-Up Rebuild*](https://talk.nervos.org/t/dis-fiber-desktop-v1-ground-up-rebuild-and-launch-fnn-desktop-app/10317/1). The project's development proposal is officially up for a vote. If you are a Nervos DAO member, be sure to cast your vote and participate in shaping this retail infrastructure.\n\n- **Check it out**: [Forum Link](https://talk.nervos.org/t/fiber-desktop-run-fiber-fnn-on-your-laptop-without-the-public-node-headache/10247/8)\n- **Participate in Governance**: [DAO Voting](https://dao.ckb.community/thread/vot-fiber-desktop-v1-ground-up-rebuild-and-launch-fnn-desktop-app-72720)\n\n### Fiber Pay v0.2.6: AI-Friendly CLI and Developer SDK Updates",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1006",
+      "id": "chunk-1008",
       "title": "Pulse 07",
       "content": "The AI-friendly command-line tool and developer SDK, **fiber-pay**, has rolled out version **v0.2.6**.\n\nThis latest release introduces optimization patches and enhances standard command operations. These enhancements provide developers with a cleaner, more robust environment when building applications that require automated, continuous micropayment streams or AI-driven agent payments\n\n- **Check it out:** [Forum Link](https://talk.nervos.org/t/fiber-pay-an-ai-friendly-cli-for-fiber-network/9974/9) & [Release Note](https://github.com/RetricSu/fiber-pay/releases/tag/v0.2.6)\n\n### **fiber-payjoin-kit: Functional PoC and Technical Specification Completed**",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1007",
+      "id": "chunk-1009",
       "title": "Pulse 07",
       "content": "A major milestone just dropped for the **fiber-payjoin-kit**, an open-source Rust library bringing collaborative Payjoin privacy natively to the Fiber Network. By letting receivers contribute inputs to channel-funding transactions, it breaks common common-input heuristic to keep payments private.\n\nThe team has focused on a functional Proof of Concept (PoC) to validate the design:",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1008",
+      "id": "chunk-1010",
       "title": "Pulse 07",
       "content": "- **Cross-Chain PoC:** They built a working local middleware PoC for collaborative channel funding on CKB, while simultaneously developing a Bitcoin Lightning equivalent (`lightning-payjoin-kit`) to validate the same collaborative pattern.\n- **Demo & Spec Ready:** The new technical specification includes a demo video showing the standalone middleware handling local negotiation, cryptographic validation, and broadcasting transactions to a local CKB devnet node.\n\n- **Check it out**: [Forum Link](https://talk.nervos.org/t/dis-fiber-payjoin-kit-collaborative-privacy-for-the-nervos-fiber-network/10296/12)\n\n### Opticrum: Decentralizing Inbound Liquidity Markets on CKB",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1009",
+      "id": "chunk-1011",
       "title": "Pulse 07",
       "content": "An architectural breakdown by community developer Ckroamer explores how CKB's Turing-complete power can build a decentralized alternative to Bitcoin's *Amboss,* named **Opticrum** (\"Optic-\" + \"Fulcrum\").\n\nIn the Lightning Network ecosystem, Amboss serves as a marketplace for buying and selling inbound liquidity, giving merchants a larger capacity to receive payments. It stands out as one of the few true liquidity markets in the Lightning space. However, due to Bitcoin's smart contract limits, Amboss has to rely on a centralized escrow and reputation system to ensure that sellers actually keep channels open.\n\nIf run on CKB, Opticrum can handle the entire lifecycle trustlessly using Layer 1 Cells:",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1010",
+      "id": "chunk-1012",
       "title": "Pulse 07",
       "content": "- **Decentralized Matching:** Instead of relying on a centralized platform, buyers post liquidity requests directly on-chain as individual Cells. Sellers find and accept these orders by simply querying on-chain.\n- **Atomic Matching:** The buyer packs both the requested channel capacity and the rental fee into a single request Cell, while the seller consumes this Cell to create the channel. Atomic matching is natively achieved this way.\n- **No Need for Monitoring**: By converting the channel’s duration into a block count and writing it into the request Cell, the seller cannot withdraw all the rent at once. Instead, they must periodically submit rent withdrawal transactions with proof that the channel still exists. This eliminates the need for monitoring entirely.",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1011",
+      "id": "chunk-1013",
       "title": "Pulse 07",
       "content": "While current limitations prevent custom extensions inside Fiber's native channel setup, the author outlines a neat two-step workaround to keep things completely decentralized without sacrificing security.\n\n- **Check it out:** [Forum Link](https://talk.nervos.org/t/fiber-ckb-fiber-amboss/10353)\n\n### Fiber Link: Wallets and Hosting Hurdles for Forum Tipping\n\n**Fiber Link**, the micro-tipping layers for digital communities, had some great chat about getting native tipping running on Nervos Talk.\n\nThe discussion highlighted the two main challenges the project is tackling right now:",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1012",
+      "id": "chunk-1014",
       "title": "Pulse 07",
       "content": "**The User-Side Wallet Barrier:** While users already have standard browser extensions, Keith clarified that the real hurdle is the lack of wallets with native Fiber routing and deep liquidity. To make tipping seamless, the ecosystem needs liquidity nodes that support channel rotation, allowing users to pull funds out without disconnecting the channel.",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1013",
+      "id": "chunk-1015",
       "title": "Pulse 07",
       "content": "**The Convenience vs. Trust Trade-Off:** Responding to architecture questions from Ckroamer, Keith explained that the forum doesn't run a centralized node. Instead, a simple plugin handles the UI, while Fiber Link acts as a cross-platform service layer that manages the ledger and receiving node. This saves tippers from paying the 61 CKB cell deposit and keeps creators from needing to run 24/7 infrastructure. It introduces a minor custodial trade-off, but it allows creators to aggregate small tips from multiple different platforms into a single balance for faster withdrawals.\n\n- **Join the Conversation**: [Forum Link](https://talk.nervos.org/t/dis-fiber-link-a-ckb-fiber-based-pay-layer-tipping-micropayments-for-communities/9845/36)\n\n### *Got an idea? Let’s Build It Together*",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1014",
+      "id": "chunk-1016",
       "title": "Pulse 07",
       "content": "Fiber Network is a community-driven ecosystem, and we have real resources dedicated to backing builders. If you’ve been thinking about hacking on a tool, an application, or core infrastructure, we want to help you get it off the ground:\n\n- **Spark Program**: A fast-track path for early prototypes, offering up to **$2,000** in funding to help turn ideas into working MVPs within 1–2 months.\n- **CKB Community Fund**: A DAO-backed grant program supporting a wide range of ecosystem work, from core development to tools, content, and community initiatives.\n\nShare your idea on the **Nervos Talk** forum and reach out to the programs above. We’d love to feature your project in our next update!\n\nKeep building 🏗️",
       "url": "/docs/pulse/issue-07",
       "source": "pulse/issue-07.md"
     },
     {
-      "id": "chunk-1015",
+      "id": "chunk-1017",
       "title": "Pulse 08",
       "content": "*The most exciting work happens when builders take the lead.*\n\n### Dular Milestone 2: Bringing Fiber Payments to Feature Phones\n\n**Dular**, a Spark Program recipient focused on bringing Fiber-powered payments to mobile money users, has completed Milestone 2 with a working USSD interface for feature phones. Tested through the Africa’s Talking simulator, as [this demo](https://drive.google.com/file/d/1RTkMGAZYImQK6vziX8Scy2EaTxhRUDtc/view) shows, the implementation now supports balance checks, PIN setup, phone-number payments, receiving details, and M-Pesa deposit initiation. The next step is deployment through a live shortcode, while withdrawal functionality awaits Safaricom B2C activation.",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1016",
+      "id": "chunk-1018",
       "title": "Pulse 08",
       "content": "The milestone also sparked discussion around Dular and Fiber. The team explained that the current prototype relies on operator-managed testnet nodes and a phone-to-pubkey registry that maps a verified phone number to the Fiber identity/receiving endpoint, while a community member emphasized the importance of future interoperability with external non-Dular Fiber users to ensure assets can move freely across the broader Fiber ecosystem.",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1017",
+      "id": "chunk-1019",
       "title": "Pulse 08",
       "content": "Dular's progress was also highlighted in the Spark Program's [Q2 report](https://talk.nervos.org/t/spark-program-q2-2026-what-the-ecosystem-is-building/10396) as an example of bringing Fiber into practical, real-world payment contexts. The report identified Fiber payment integration in real-world scenarios as an anticipated direction, with Dular’s mobile money pilot demonstrating how Fiber can extend beyond crypto-native users and support everyday payment applications.\n\n- **Check it out**: [Forum link](https://talk.nervos.org/t/spark-program-dular/10212/13)\n- **Support**: Backed by the Spark Program\n\n### Fiber Desktop Evolves into Fiber Studio as v1 Development Begins",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1018",
+      "id": "chunk-1020",
       "title": "Pulse 08",
       "content": "The proposal for **Fiber Studio** recently passed a Community Fund DAO vote with 100% approval, securing support for the next stage of development. Building on the earlier Fiber Desktop prototype, Fiber Studio aims to make running and using a Fiber Network Node (FNN) as simple as installing a desktop application. Planned features include guided node setup, channel and peer management, payment and invoice workflows, network visualization tools, and cross-platform support for macOS, Windows, and Linux.",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1019",
+      "id": "chunk-1021",
       "title": "Pulse 08",
       "content": "The project represents an evolution from a proof-of-concept interface into a more complete user environment for the Fiber Network. By the end of the roadmap, users should be able to install the application, connect to the network, open channels, send and receive payments, and manage their node through a graphical interface rather than command-line tools.\n\n- **Check it out**: [Forum link](https://talk.nervos.org/t/dis-fiber-desktop-v1-ground-up-rebuild-and-launch-fnn-desktop-app/10317/1) & [GitHub repo](https://github.com/chukwuma619/fiber-studio)\n- **Support**: Backed by the CKB Community Fund\n\n### Infern: A Fiber-Powered Marketplace for AI Inference",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1020",
+      "id": "chunk-1022",
       "title": "Pulse 08",
       "content": "Community developer truthixify introduced **Infern**, an open-source project exploring a marketplace where individuals can serve AI models from their own hardware and earn payments per request through Fiber. \n\nThe project targets the growing number of independent AI operators with spare compute capacity or specialized models, providing a way to monetize inference without traditional accounts, billing systems, or centralized platforms.",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1021",
+      "id": "chunk-1023",
       "title": "Pulse 08",
       "content": "Infern combines CKB’s shared state capabilities with Fiber's fast micropayments: CKB tracks provider listings, reputation, and staking, while Fiber enables low-cost payment channels for AI inference requests. The project is currently running on testnet with a working flow for registering models, connecting providers, and paying for inference requests. The community is now discussing topics including provider verification, routing, and the long-term design of a decentralized AI compute marketplace.\n\n- **Check it out**: [Forum link](https://talk.nervos.org/t/introducing-infern-serve-an-ai-model-from-your-own-machine-and-get-paid-per-request-over-fiber/10408) & [GitHub](https://github.com/truthixify/infern)",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1022",
+      "id": "chunk-1024",
       "title": "Pulse 08",
       "content": "One theme stood out this cycle: **accessibility**. Whether it's making payments available on feature phones, turning node management into a desktop experience, or enabling individuals to monetize AI models, builders are finding ways to lower barriers and expand what Fiber can be used for. We'll continue tracking these projects as they evolve and sharing the latest developments from across the ecosystem.\n\nThese projects also highlight something else: the ecosystem is becoming increasingly supportive of experimentation. From early prototypes to production-focused applications, builders have access to funding, feedback, and an active community willing to help refine ideas and test new approaches.\n\nIf you're working on a project of your own, there are multiple ways to get support:",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1023",
+      "id": "chunk-1025",
       "title": "Pulse 08",
       "content": "- **Spark Program**: A fast-track initiative for early ideas—up to $2,000 USD to get from concept to a working MVP in ~1–2 months.\n- **CKB Community Fund**: A broader, community-driven DAO providing grants for a wide range of Nervos contributions, from code development to content production and event organizing.\n\nEvery project featured in this update started as an idea shared with the community. If you're building something with Fiber, consider posting it on the [**Nervos Talk forum**](https://talk.nervos.org/)--we'd love to follow its progress and feature it in a future update.\n\n**Enjoy building!**\n\n**Fiber Devs**",
       "url": "/docs/pulse/issue-08",
       "source": "pulse/issue-08.md"
     },
     {
-      "id": "chunk-1024",
+      "id": "chunk-1026",
+      "title": "Pulse 10",
+      "content": "*The most exciting work happens when builders take the lead.*\n\n### Fiber Studio: Visual Overhaul and Easier Node Migration\n\n**Fiber Studio** released [v0.1.9](https://github.com/nervosnetwork/fiber/releases/tag/v0.9.0-rc7) with a UI visual revamp to improve readability. This update is driven by tester feedback while maintaining familiar payment flows.\n\nThis release bundles the fnn v0.9.0-rc7 node. This node upgrade requires a database migration, and Fiber Studio now handles the entire process directly in the interface. Error handling for routing and payment failures is also clearer in this release. Instead of outputting raw node text, the app provides plain-language summaries.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1027",
+      "title": "Pulse 10",
+      "content": "- Links: [Website](https://www.getfiberstudio.com/), [v0.1.9](https://github.com/chukwuma619/fiber-studio/releases) release and [forum discussion](https://talk.nervos.org/t/dis-fiber-desktop-v1-ground-up-rebuild-and-launch-fnn-desktop-app/10317/22).\n- Support: CKB Community Fund\n\n### Dular | Redirecting to A More Decentralized Mobile Web/PWA\n\n**Dular** is pausing its production USSD deployment, pivoting to a self-custodial, mobile Progressive Web App (PWA) flow. This redirection is best understood as a practical redesign, due to the constraints from their telecom provider Africa’s Talking, as well as an architectural update based on committee feedback.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1028",
+      "title": "Pulse 10",
+      "content": "Though a functioning USSD interface was simulator-tested, it is currently blocked for production. The telecom provider requires a dedicated USSD code for crypto services, which exceeds the grant budget. USSD will not be used as the main live testing channel.\n\nArchitecturally, committee feedback pointed out that Dular’s initial, more centralized ledger custodied user keys, undermining Fiber's core purpose. To resolve this, Dular will use a mobile browser running Fiber WASM. Devices can locally generate and store keys for self-custody, while the backend strictly maps phone numbers to user-owned Fiber identities for seamless, interoperable payments.\n\n- Link: [Forum discussion](https://talk.nervos.org/t/spark-program-dular/10212/25)\n- Support: Spark Program",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1029",
+      "title": "Pulse 10",
+      "content": "### Paying a Bitcoin Lightning Invoice with CKB UDT on Fiber\n\nThis testnet demo shows Fiber’s Cross-Chain Hub (CCH) in action. In the example, the CKB-side asset is cWBTC, while the Lightning payment is handled through LND, turning Fiber’s cross-network payment design into a working end-to-end demo.\n\n- Links: [Live Demo](https://fiber-swap.retric.uk), GitHub [Repo](https://github.com/humble-little-bear/fiber-swap-demo), and [forum discussion](https://talk.nervos.org/t/paying-a-bitcoin-lightning-invoice-with-ckb-udt-on-fiber/10486)\n\n### Bringing Fiber to Mobile: Native iOS and Android Integration",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1030",
+      "title": "Pulse 10",
+      "content": "**Fiber’s FFI layer** (`fiber-ffi`) wraps Rust fiber-lib as a stable C ABI, giving native Android and iOS apps a way to embed and interact with a Fiber node directly. This gives mobile developers a practical path to integrate Fiber into Swift and Kotlin applications, including node lifecycle control and direct RPC access from mobile environments.\n\nThe technical [guide](https://talk.nervos.org/t/bringing-fiber-to-mobile-apps-ffi-android-and-ios-native-integration/10478) explains how this integration works and outlines a reusable approach for bringing Fiber into mobile apps through an FFI boundary.\n\n### fiber-pay v0.3.0 | UDT Operation Support",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1031",
+      "title": "Pulse 10",
+      "content": "The AI-friendly CLI tool **fiber-pay** released [v0.3.0](https://github.com/RetricSu/fiber-pay/releases/tag/v0.3.0), with support for User Defined Token (UDT) operations. \n\nFiber-pay was introduced as a developer- and AI-friendly interface to Fiber with JSON-oriented workflows for node interaction, channel management, and payments. This release pushes that idea further by adding asset support that is relevant to more advanced payment and application scenarios.\n\n- Links: [v0.3.0](https://github.com/RetricSu/fiber-pay/releases/tag/v0.3.0) release and [forum discussion](https://talk.nervos.org/t/fiber-pay-an-ai-friendly-cli-for-fiber-network/9974/11)\n\n### Trickle: Budget-Capped Streaming Micropayments for Fiber Network",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1032",
+      "title": "Pulse 10",
+      "content": "**Trickle** is a budget-capped, streaming micropayment system built for Fiber. It enables seamless, pay-as-you-go billing for continuous or high-frequency services like AI token usage, APIs, and agent-to-agent transactions.\n\nIts main idea is to authorize a budget once and then settle many small usage events under that approved budget. This avoids opening a separate HTLC hold for every tiny payment, which would lock liquidity repeatedly and create UI friction.\n\n- Links: [Forum discussion](https://talk.nervos.org/t/trickle-budget-capped-streaming-micropayments-for-fiber-network/10493)\n\n### Proposal | Fiber Payment Gateway for WooCommerce\n\nThis proposal aims to build a WooCommerce payment plugin that lets merchants accept Fiber payments through their existing stores and their own Fiber nodes.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1033",
+      "title": "Pulse 10",
+      "content": "At checkout, the plugin would generate an invoice for the order, display it as a QR code plus copyable invoice string, then watch for settlement through Fiber node webhooks or polling and update the WooCommerce order automatically once the payment is settled.\n\n- Link: [Forum discussion](https://talk.nervos.org/t/spark-program-fiber-network-payment-gateway-for-woocommerce/10500)\n\n### Proposal | Fiber Pay Studio: An End-User-Friendly Dashboard\n\n**Fiber Pay Studio** is a web app that gives end users a simple way to try Fiber payments without running their own frontend. Currently, interacting with a Fiber node requires raw RPC calls or CLI tooling. This project replaces that with a simple, hosted dashboard.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1034",
+      "title": "Pulse 10",
+      "content": "Users can easily generate shareable payment requests, pay them via the CCC wallet connector, and track the channel balances and payment history in real time.\n\nUnlike [Fiber Checkout](https://talk.nervos.org/t/spark-program-fiber-checkout-a-stripe-style-react-payment-library-for-fiber-network/10045), another community project focused on providing a developer library, Fiber Pay Studio is a no-code, ready-to-use application. It allows anyone to experience a Fiber payment end-to-end without running their own infrastructure. Furthermore, these two projects are complementary rather than duplicative: once Fiber Checkout’s component library matures, Fiber Pay Studio can be built on top of it as a reference implementation.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1035",
+      "title": "Pulse 10",
+      "content": "- Link: [Forum discussion](https://talk.nervos.org/t/spark-program-fiber-pay-studio/10485/4)\n\n### Proposal | VibeQuest: Turning AI-Assisted Coding Into Real Learning\n\nVibeQuest is a gamified educational onboarding platform and coding workbench. It is designed to close the gap between writing code with AI and actually understanding it. The project transforms the common workflow of vibe coding into a structured learning loop tailored for the Nervos CKB and Fiber ecosystems.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1036",
+      "title": "Pulse 10",
+      "content": "The current MVP covers two subjects: CKB Cell Model and Fiber Payment Models. The CKB Cell Model teaches how cells, Outputs, Scripts, witnesses, and verifier logic operate. Fiber Payment Models cover invoices, payment proofs, channel state, and replay risks to ensure developers know how off-chain payment evidence is secured.\n\n- Links: [Forum discussion](https://talk.nervos.org/t/spark-program-vibequest-turning-ai-assisted-coding-into-real-learning/10446)\n\n### Proposal | Fiber RGB++ Swap: Cross-Chain Assets Over Fiber",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1037",
+      "title": "Pulse 10",
+      "content": "**Fiber RGB++ Swap** is an infrastructure upgrade that enables atomic, cross-chain swaps between RGB++ Bitcoin assets and CKB directly over the Fiber Network. It allows users to trade assets across networks without relying on custodial bridges or waiting for separate block confirmations.\n\nCurrently, Fiber's Cross-Chain Hub (CCH) is hardcoded to support only a 1:1 swap between Bitcoin and wrapped BTC on CKB. This project removes that limitation by introducing a two-part solution:\n\n**The Advertisement Mechanism:** Hub operators broadcast a signed `SwapAdvertisement` message over Fiber’s existing peer gossip layer. This allows hubs to publicly declare the specific asset pairs and exchange rates they support, removing the single-pair limitation.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1038",
+      "title": "Pulse 10",
+      "content": "**The Swap Client:** A client tool discovers a compatible hub via the advertisement and initiates the trade. It uses generalized HTLC logic to validate the RGB++ assets and execute a full atomic swap (RGB++ asset in, CKB asset out).\n\n- Link: [Forum discussion](https://talk.nervos.org/t/spark-program-fiber-rgb-swap/10487)\n\n### Opticrum | Decentralized Liquidity Market for Fiber\n\n**Opticrum** is an on-chain liquidity marketplace built on CKB that connects users who need Fiber channel capacity with Liquidity Providers (LPs) who can supply it.\n\nBuyers publish \"Order Cells\" on-chain, specifying the required channel capacity and locking the rent they are willing to pay. Sellers (LPs) use their Fiber nodes to accept orders and collect linearly released rent.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1039",
+      "title": "Pulse 10",
+      "content": "- Link: [Forum discussion](https://talk.nervos.org/t/fiber-opticrum/10495)\n\n### FiberPass: Prepaid, Revocable Payment Sessions\n\n**FiberPass** is a wallet and payment UX infrastructure designed to simplify recurring and automated transactions on the Fiber Network. Users approve a spending limit only once, then the connected applications can execute subsequent payments automatically as long as they stay within the approved rules. \n\nCurrently live in beta on the CKB testnet, the project is actively seeking ecosystem feedback.\n\n- Link: [Demo](https://fiberpassfrontend.vercel.app/) and [forum discussion](https://talk.nervos.org/t/fiberpass-prepaid-revocable-payment-sessions-for-fiber-network/10491)\n\n### *Building something of your own?*",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1040",
+      "title": "Pulse 10",
+      "content": "If you have an idea in progress, there are a few pathways to get educational and financial backing from the Nervos ecosystem:\n\n- **Spark Program:** A fast-track initiative tailored for early-stage concepts. It offers up to $2,000 USD to help you move from a raw idea to a working MVP within one to two months.\n- **CKB Community Fund:** A broader, community-governed DAO that provides grants for a wide range of contributions, whether you are writing core code, creating educational content, or organizing community events.\n- **CKBuilders**: A structured initiative offering microgrant-backed tracks for developers, content creators, and organizers. It provides monthly stipends, guided learning pipelines, and a supportive peer cohort to help you shape early prototypes.",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1041",
+      "title": "Pulse 10",
+      "content": "Every project featured in our ecosystem updates began as an idea shared openly on the forum. If you are building with Fiber, we highly encourage you to share your journey on the [Nervos Talk](https://talk.nervos.org/) forum. We would love to follow your progress and feature your work in an upcoming issue.\n\nEnjoy the process!\n\nFiber Devs",
+      "url": "/docs/pulse/issue-10",
+      "source": "pulse/issue-10.md"
+    },
+    {
+      "id": "chunk-1042",
       "title": "Pulse 09",
       "content": "*The most exciting work happens when builders take the lead.*\n\n### Dular | Navigating USSD Blockers and System Architecture\n\n**Dular**, an in-progress Spark Program project, is building a Fiber-based stablecoin wallet designed for mobile users.\n\nThe team is currently navigating a milestone blocker regarding production USSD access. Their original plan relied on Africa's talking shared USSD service; However, they recently learned that crypto-related applications require a dedicated USSD setup. This requirement pushes costs significantly beyond the current milestone budget. Dular is actively evaluating alternative solutions, has set a strict deadline for the coming week to finalize their USSD path, and has committed to resuming weekly updates to keep the community informed.",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1025",
+      "id": "chunk-1043",
       "title": "Pulse 09",
       "content": "Meanwhile, active discussions are diving into core implementation details. The community is reviewing how the system will work in practice, focusing on custody models, operator dependence, liquidity management, and Fiber channel architecture.\n\nAs a result, the project's immediate focus has shifted from delivering new features to resolving this foundational access blocker and refining the system design alongside the community.\n\n- **Join the conversation**: [Dular update](https://talk.nervos.org/t/spark-program-dular/10212/21)\n- **Support**: Spark Program\n\n### Fiber Desktop | Reaches Milestone 2: Full UI for Testnet Payments",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1026",
+      "id": "chunk-1044",
       "title": "Pulse 09",
       "content": "**Fiber Desktop v1** has completed Milestone 2. Essential features—including wallet, peers, channels, and network features—are now live on top of the official FNN node. The application now supports end-to-end testnet payments through a desktop UI, delivering seamless invoice handling, channel management, relay connectivity, and network browsing. With this release, Fiber Desktop is positioned as a highly accessible, ready-to-use testing tool for builders who want to send and receive payments without relying on terminal commands.",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1027",
+      "id": "chunk-1045",
       "title": "Pulse 09",
       "content": "The upcoming Milestone 3 will shift focus from core functionality to product launch and final polish. Remaining deliverables include: cross-platform testing, signed distribution, enhanced operational tooling, mainnet readiness, rebranding, website rollout, and the v1.0.0 release.\n\n- **Check it out**: [Milestone 2 update](https://talk.nervos.org/t/dis-fiber-desktop-v1-ground-up-rebuild-and-launch-fnn-desktop-app/10317/19)\n- **Support**:  CKB Community Fund\n\n### Fiber-Pay v0.2.7 | FNN Adaptation and New Developer Landing Page",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1028",
+      "id": "chunk-1046",
       "title": "Pulse 09",
       "content": "Fiber-pay, the CLI and SDK toolchain designed for the Fiber network, has released [v0.2.7](https://github.com/RetricSu/fiber-pay/releases/tag/v0.2.7). This update primarily focuses on adapting the tools to ensure compatibility with the 0.9.0-rc4 version of FNN. Additionally, it resolves a bug that previously caused the CLI to mistakenly download the pre-release FNN binary.\n\nBeyond technical fixes, a [landing page](https://retricsu.github.io/fiber-pay/) was launched. Designed as a dedicated entry point, the site helps developers quickly learn about the toolchain and get started with their builds. Fiber-pay’s mission continues to be providing builders with a robust, AI-friendly CLI and SDK option for the Fiber network.",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1029",
+      "id": "chunk-1047",
       "title": "Pulse 09",
       "content": "- **Landing page**: [Fiber-Pay](https://retricsu.github.io/fiber-pay/)\n- **Join the conversation**: [Forum discussion](https://talk.nervos.org/t/fiber-pay-an-ai-friendly-cli-for-fiber-network/9974/10)\n\n### Proposal | FiberLatch Access: Open-Source Access Control for Fiber Payments",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1030",
+      "id": "chunk-1048",
       "title": "Pulse 09",
       "content": "**FiberLatch Access** is a open-source access-control layer proposal, designed to work alongside existing Fiber payment tools, such as fiber-pay. While the payment tool handles the transaction, FiberLatch Access manages what happens *after* the payment—specifically, granting and managing access to gated resources like premium content, APIs, or private files. Instead of requiring developers to build access logic from scratch, FiberLatch Access will provide a lightweight Node.js package, featuring a standardized access receipt format, clear expiration rules, replay protection to prevent receipt reuse, and a working paid-resource example.",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1031",
+      "id": "chunk-1049",
       "title": "Pulse 09",
       "content": "Built upon the developer's earlier work [**FiberLatch**](https://github.com/Nervos-Community-Catalyst/CKBuilder-projects/issues/17) in the [CKBuilder program](https://nervoscatalyst.org/community-keeps-building), FiberLatch Access has submitted a $3,000 grant proposal to the CKB Community Fund DAO. The project is currently in the active DAO voting stage.\n\n- **Vote**: [Link](https://dao.ckb.community/thread/vot-fiberlatch-access-open-source-access-control-for-fiber-payments-74170)\n- **Join the conversation:** [FiberLatch Access Proposal](https://talk.nervos.org/t/dis-fiberlatch-access-open-source-access-control-for-fiber-payments/10414)\n\n### Proposal | Fiber Python SDK: Native Library for Fiber Network Payments",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1032",
+      "id": "chunk-1050",
       "title": "Pulse 09",
       "content": "The **Fiber Python SDK** is a proposed library designed to bring native Python support to the Fiber Network. Currently, Fiber's developer tooling is primarily built for TypeScript or JavaScript. This project aims to provide a fully typed, asynchronous Python package fiber-sdk that wraps the Fiber Network Node JSON-RPC interface. The proposed SDK would cover the entire payment lifecycle, including channels, peers, invoices, and Bitcoin cross-chain interoperability, making it straightforward for Python developers and AI agent frameworks to interact with Fiber without needing to write raw JSON-RPC from scratch.\n\nThe project is currently an active grant proposal. The developer is requesting $5,000 (equivalent in CKB) to fund an eight-week development timeline.",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1033",
+      "id": "chunk-1051",
       "title": "Pulse 09",
       "content": "- **Join the conversation**: [Fiber Python SDK Proposal](https://talk.nervos.org/t/dis-fiber-python-sdk-native-python-library-for-fiber-network-payments/10462)\n\n### Proposal | VibeQuest: Turning AI-Assisted Coding Into Real Learning",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1034",
+      "id": "chunk-1052",
       "title": "Pulse 09",
       "content": "**VibeQuest** is a proposal for an AI-assisted learning product that aims to turn vibe coding into actual understanding. Its goal is to help users learn CKB and Fiber by guiding them through structured lessons, quests, code verification, and challenge-based checkpoints, instead of letting them rely on AI-generated code without comprehension. The project proposes an interactive learning loop featuring AI-generated educational content, a quest/challenge system, and a workbench to ensure developers can practically verify and prove their understanding of the ecosystem.\n\nThe project is currently under early review for a $1,000 grant. The team is updating the proposal to address initial feedback and suggestions from the community.",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1035",
+      "id": "chunk-1053",
       "title": "Pulse 09",
       "content": "- **Join the conversation:** [VibeQuest Proposal](https://talk.nervos.org/t/spark-program-vibequest-turning-ai-assisted-coding-into-real-learning/10446)\n\n**Building something of your own?**\n\nIf you have an idea in progress, there are a few pathways to get educational and financial backing from the Nervos ecosystem:",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1036",
+      "id": "chunk-1054",
       "title": "Pulse 09",
       "content": "- **Spark Program:** A fast-track initiative tailored for early-stage concepts. It offers up to $2,000 USD to help you move from a raw idea to a working MVP within one to two months.\n- **CKB Community Fund:** A broader, community-governed DAO that provides grants for a wide range of contributions, whether you are writing core code, creating educational content, or organizing community events.\n- **CKBuilders**: A structured initiative offering microgrant-backed tracks for developers, content creators, and organizers. It provides monthly stipends, guided learning pipelines, and a supportive peer cohort to help you shape early prototypes.",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1037",
+      "id": "chunk-1055",
       "title": "Pulse 09",
       "content": "Every project featured in our ecosystem updates began as an idea shared openly on the forum. If you are building with Fiber, we highly encourage you to share your journey on the [Nervos Talk](https://talk.nervos.org/) forum. We would love to follow your progress and feature your work in an upcoming issue.\n\nEnjoy the process,\n\nFiber Devs",
       "url": "/docs/pulse/issue_09",
       "source": "pulse/issue_09.md"
     },
     {
-      "id": "chunk-1038",
+      "id": "chunk-1056",
       "title": "biscuit-auth",
       "content": "# Biscuit Authentication in Fiber\n\nThis document provides an overview of Biscuit authentication, how it's integrated into Fiber's RPC system, and how to use it.\n\n## 1. What is Biscuit Authentication?\n\n[Biscuit] is a modern authorization token format designed for distributed verification. It's similar in concept to other bearer tokens like JWTs (JSON Web Tokens).\n\n## 2. How Biscuit Auth Works in Fiber RPC\n\nBiscuit is integrated into the Fiber RPC, it can be disabled when RPC is listen to private addr, but must be enabled when listen to public address. When enabled, it protects RPC endpoints by requiring a valid Biscuit token with permission for resources.\n\nHere's a step-by-step breakdown of the process:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1039",
+      "id": "chunk-1057",
       "title": "biscuit-auth",
       "content": "1.  **Client Request**: The client sends an RPC request and includes the Biscuit token in the `Authorization` HTTP header, formatted as a `Bearer` token. The token itself is Base64-encoded.\n\n2.  **Middleware Interception**: On the server, the `BiscuitAuthMiddleware` intercepts every incoming RPC request before it reaches the actual method handler.\n\n3.  **Token Extraction and Verification**: The middleware extracts the Base64-encoded token from the header, decodes it, and verifies its signature using the server's configured public key. If the signature is invalid, the request is immediately rejected.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1040",
+      "id": "chunk-1058",
       "title": "biscuit-auth",
       "content": "4.  **Rule-based Authorization**: If the signature is valid, the middleware proceeds to the authorization step.\n    *   Fiber maintains a predefined set of authorization rules for each RPC method. For example, the `open_channel` method requires a token with the `write(\"channels\")` permission.\n    *   The middleware builds a Biscuit **Authorizer**. This authorizer is loaded with the rule corresponding to the RPC method being called.\n    *   It also adds contextual facts to the authorizer, such as the current time (e.g., `time(2023-10-27T10:00:00Z)`) and any parameters from the request. This allows for policies that depend on time or specific request data.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1041",
+      "id": "chunk-1059",
       "title": "biscuit-auth",
       "content": "5.  **Policy Execution**: The authorizer then evaluates the token against the loaded rules and facts. It checks if the permissions granted in the token (the \"authority\" block and any attenuated blocks) satisfy the requirements of the RPC method's policy.\n\n6.  **Access Control**:\n    *   If the authorization check passes, the middleware forwards the request to the intended RPC method, and the operation proceeds.\n    *   If the check fails (either due to insufficient permissions or a failed check like an expired timestamp), the middleware rejects the request with an \"Unauthorized\" error.\n\nThis entire process happens transparently for the RPC methods themselves. The logic is neatly contained within the middleware, ensuring that security is applied consistently across all protected endpoints.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1042",
+      "id": "chunk-1060",
       "title": "biscuit-auth",
       "content": "The current rules for each RPC methods:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1043",
+      "id": "chunk-1061",
       "title": "biscuit-auth",
       "content": "``` rust\n// Cch \nrule(\"send_btc\", r#\"allow if write(\"cch\");\"#); \nrule(\"receive_btc\", r#\"allow if write(\"cch\");\"#);\nrule(\"get_cch_order\", r#\"allow if read(\"cch\");\"#); \n// channels \nrule(\"open_channel\", r#\"allow if write(\"channels\");\"#); \nrule(\"accept_channel\", r#\"allow if write(\"channels\");\"#); \nrule(\"abandon_channel\", r#\"allow if write(\"channels\");\"#); \nrule(\"list_channels\", r#\"allow if read(\"channels\");\"#); \nrule(\"shutdown_channel\", r#\"allow if write(\"channels\");\"#); \nrule(\"update_channel\", r#\"allow if write(\"channels\");\"#); \n// dev \nrule(\"commitment_signed\", r#\"allow if write(\"dev\");\"#);\nrule(\"add_tlc\", r#\"allow if write(\"dev\");\"#);\nrule(\"remove_tlc\", r#\"allow if write(\"dev\");\"#);\nrule(\"check_channel_shutdown\", r#\"allow if write(\"dev\");\"#);\nrule(\"sign_external_funding_tx\", r#\"allow if write(\"dev\");\"#);\nrule(\"submit_commitment_transaction\", r#\"allow if write(\"dev\");\"#);\n// graph \nrule(\"graph_nodes\", r#\"allow if read(\"graph\");\"#); \nrule(\"graph_channels\", r#\"allow if read(\"graph\");\"#);",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1044",
+      "id": "chunk-1062",
       "title": "biscuit-auth",
       "content": "// info \nrule(\"node_info\", r#\"allow if read(\"node\");\"#); \nrule(\"new_invoice\", r#\"allow if write(\"invoices\");\"#); \nrule(\"parse_invoice\", r#\"allow if read(\"invoices\");\"#); \nrule(\"get_invoice\", r#\"allow if read(\"invoices\");\"#); \nrule(\"cancel_invoice\", r#\"allow if write(\"invoices\");\"#); \nrule(\"settle_invoice\", r#\"allow if write(\"invoices\");\"#); \n\n// payment \nrule(\"send_payment\", r#\"allow if write(\"payments\");\"#); \nrule(\"get_payment\", r#\"allow if read(\"payments\");\"#); \nrule(\"build_router\", r#\"allow if read(\"payments\");\"#); \nrule(\"send_payment_with_router\", r#\"allow if write(\"payments\");\"#); \n\n// peer \nrule(\"connect_peer\", r#\"allow if write(\"peers\");\"#); \nrule(\"disconnect_peer\", r#\"allow if write(\"peers\");\"#); \nrule(\"list_peers\", r#\"allow if read(\"peers\");\"#);",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1045",
+      "id": "chunk-1063",
       "title": "biscuit-auth",
       "content": "// watchtower \nrule( \n    \"create_watch_channel\", \n    r#\" \n    allow if write(\"watchtower\"); \n    allow if right({channel_id}, \"watchtower\"); \n    \"#, \n); \nrule( \n    \"remove_watch_channel\", \n    r#\" \n    allow if write(\"watchtower\"); \n    allow if right({channel_id}, \"watchtower\"); \n    \"#, \n); \nrule( \n    \"update_revocation\", \n    r#\" \n    allow if write(\"watchtower\"); \n    allow if right({channel_id}, \"watchtower\"); \n    \"#, \n); \nrule(\n    \"update_pending_remote_settlement\",\n    r#\"\n    allow if write(\"watchtower\");\n    allow if right({channel_id}, \"watchtower\");\n    \"#,\n);\nrule( \n    \"update_local_settlement\", \n    r#\" \n    allow if write(\"watchtower\"); \n    allow if right({channel_id}, \"watchtower\"); \n    \"#, \n); \nrule(\"create_preimage\", r#\"allow if write(\"watchtower\");\"#); \nrule(\"remove_preimage\", r#\"allow if write(\"watchtower\");\"#); \n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1046",
+      "id": "chunk-1064",
       "title": "biscuit-auth",
       "content": "## 3. How to Configure Biscuit Auth in Fiber\n\nEnabling Biscuit authentication on a Fiber node is a two-step process: first, you generate a cryptographic key pair, and second, you provide the public key to the Fiber server. This public key is used to verify the signatures of incoming Biscuit tokens, and its presence in the configuration automatically activates the authentication middleware.\n\n### a. Generate a Key Pair\n\nTo sign and verify tokens, you need an Ed25519 key pair. You can generate one using the `biscuit-cli` tool.\n\nPlease refer to the [official Biscuit documentation][biscuit-doc] for usage.\n\n``` bash\n# make sure you use 0.6.0 version\ncargo install biscuit-cli --vers 0.6.0-beta.2\n```\n\n```bash\nbiscuit keypair\n```\n\nThis command will output a private and a public key.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1047",
+      "id": "chunk-1065",
       "title": "biscuit-auth",
       "content": "```\nGenerating a new random keypair\nPrivate key: ed25519-private/89d6c88919e5ca326fbb8d1cbef406df08c0620575376651d53008762dc81f45\nPublic key: ed25519/17b172749be74276f0ed35a5d0685752684a3c5722114bba447a2f301136db79\n```\n\n**Important**: The **private key** is a secret and should be stored securely. It is used to sign and create new authorization tokens. The **public key** is what you will use to configure the Fiber server.\n\n### b. Configure the Public Key\n\nYou can provide the public key to your Fiber node in one of the following ways:\n\n#### Through the Configuration File\n\nAdd the public key to your Fiber configuration file (e.g., `config.yml`) under the `rpc` section:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1048",
+      "id": "chunk-1066",
       "title": "biscuit-auth",
       "content": "```yaml\nrpc:\n  # ... other rpc settings\n  biscuit_public_key: \"ed25519/17b172749be74276f0ed35a5d0685752684a3c5722114bba447a2f301136db79\" # Your ed25519 public key string\n```\n\n#### Using Command-Line Arguments\n\nWhen starting the `fiber-bin` executable, you can pass the public key as a command-line argument:\n\n```bash\nfiber-bin --rpc-biscuit-public-key \"ed25519/17b172749be74276f0ed35a5d0685752684a3c5722114bba447a2f301136db79\"\n```\n\n#### Via Environment Variables\n\nYou can also configure it using an environment variable:\n\n```bash\nexport RPC_BISCUIT_PUBLIC_KEY=\"ed25519/17b172749be74276f0ed35a5d0685752684a3c5722114bba447a2f301136db79\"\nfiber-bin\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1049",
+      "id": "chunk-1067",
       "title": "biscuit-auth",
       "content": "If `biscuit_public_key` is not set, the RPC server will not require authentication. For security, Fiber will refuse to start on a public IP address if authentication is not enabled.\n\n## 4. How to Sign an Auth Token\n\nOnce your server is configured for authentication, you need to create signed Biscuit tokens to access its RPC endpoints. This is done using the **private key** generated by `biscuit-cli`.\n\n### a. Define Permissions\n\nFirst, create a file (e.g., `permissions.bc`) to define the permissions for the token. These permissions are expressed as Datalog facts and checks, find details in the biscuit [documentation][biscuit-doc].\n\nFor example, to grant read access to peers, write access to payments, and add an expiration date:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1050",
+      "id": "chunk-1068",
       "title": "biscuit-auth",
       "content": "```datalog\n// Grant permissions for specific modules\nread(\"peers\");\nwrite(\"payments\");\n\n// You can also add checks, like an expiration date.\n// This check ensures the token is only valid before the specified UTC timestamp.\ncheck if time($time), $time <= 2025-01-01T00:00:00Z;\n```\n\n### b. Generate the Token\n\nUse the `biscuit generate` command with your private key and the permissions file to create the token.\n\n```bash\nbiscuit generate --private-key ed25519-private/89d6c88919e5ca326fbb8d1cbef406df08c0620575376651d53008762dc81f45 permissions.bc\n```\n\nThe command will output a long Base64-encoded string. This is your bearer token.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1051",
+      "id": "chunk-1069",
       "title": "biscuit-auth",
       "content": "```\nErsBClEKBXBlZXJzCghwYXltZW50cxgDIgkKBwgAEgMYgAgiCQoHCAESAxiBCDImCiQKAggbEgYIBRICCAUaFgoECgIIBQoICgYggIvSuwYKBBoCCAISJAgAEiDAjoKKNTZpA61ImgoD5Q2sSbBjA3ixK1R2M65a2TOxbRpA4SF04LS5zD6OempqQObA2TTlTCANI7bZkDpl7JIecjR59GFoNtyKYak-_jXq2gDUHadj2I8SbJ0N-vN1RPslDSIiCiBR7VZ7ZJaPE4nhxUUpgpd5MXr3hqi0RfNERy3NE4KjaQ==\n```\n\n### c. Using the Token\n\nYou can now use this token in the `Authorization` header when making RPC calls to your Fiber node:\n\n```\nAuthorization: Bearer ErsBClEKBXBlZXJzCghwYXltZW50cxgDIgkKBwgAEgMYgAgiCQoHCAESAxiBCDImCiQKAggbEgYIBRICCAUaFgoECgIIBQoICgYggIvSuwYKBBoCCAISJAgAEiDAjoKKNTZpA61ImgoD5Q2sSbBjA3ixK1R2M65a2TOxbRpA4SF04LS5zD6OempqQObA2TTlTCANI7bZkDpl7JIecjR59GFoNtyKYak-_jXq2gDUHadj2I8SbJ0N-vN1RPslDSIiCiBR7VZ7ZJaPE4nhxUUpgpd5MXr3hqi0RfNERy3NE4KjaQ==\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1052",
+      "id": "chunk-1070",
       "title": "biscuit-auth",
       "content": "This token grants exactly the permissions you defined and will be successfully verified by a Fiber server configured with the corresponding public key.\n\n## 5. Test Examples\n\nThe Fiber codebase contains numerous tests that demonstrate the usage of Biscuit tokens. These are excellent resources for understanding the system.\n\n### a. RPC Integration Tests\n\nThe file `crates/fiber-lib/src/fiber/tests/rpc.rs` contains integration-style tests for the RPC interface. Key examples include:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1053",
+      "id": "chunk-1071",
       "title": "biscuit-auth",
       "content": "*   `test_rpc_basic_with_auth`: Shows how to make multiple authenticated RPC calls with a single token.\n*   `test_rpc_auth_without_token`: Demonstrates that an unauthenticated request to a protected endpoint is rejected.\n*   `test_rpc_auth_with_invalid_token`: Tests that a token signed by an incorrect private key is rejected.\n*   `test_rpc_auth_with_wrong_permission`: Shows that a valid token with insufficient permissions is correctly denied access.\n\n[Link to file: `crates/fiber-lib/src/fiber/tests/rpc.rs`](../crates/fiber-lib/src/fiber/tests/rpc.rs)\n\n### b. Unit Tests for Authorization Logic",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1054",
+      "id": "chunk-1072",
       "title": "biscuit-auth",
       "content": "The file `crates/fiber-lib/src/rpc/biscuit.rs` contains unit tests that focus specifically on the token authorization logic. These are useful for seeing how different kinds of Datalog rules are handled.\n\n*   `test_biscuit_auth`: Basic tests for checking `read` and `write` permissions.\n*   `test_biscuit_auth_channel`: A more advanced example of granting permissions based on request parameters (in this case, a `channel_id`).\n*   `test_biscuit_token_timeout`: Demonstrates how to create and verify a token with an expiration date.\n\n[Link to file: `crates/fiber-lib/src/rpc/biscuit.rs`](../crates/fiber-lib/src/rpc/biscuit.rs)\n\n[biscuit]: https://www.biscuitsec.org/\n[biscuit-doc]: https://doc.biscuitsec.org/usage/command-line",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/biscuit-auth.md",
       "source": "biscuit-auth.md"
     },
     {
-      "id": "chunk-1055",
+      "id": "chunk-1073",
       "title": "channel-rebalancing",
       "content": "# Channel Rebalancing\n\nChannel rebalancing lets you shift liquidity between your channels without\nopening or closing any channel. It works by sending a **circular payment** —\nfunds flow out through one channel and back in through another. Your total\nbalance stays the same; only routing fees paid to intermediate nodes are\ndeducted.\n\n## When to Rebalance\n\nSuppose you have two channels:\n\n```\nYou --[Channel A]--> Peer A    (local: 90, remote: 10)\nYou --[Channel B]--> Peer B    (local: 10, remote: 90)\n```\n\nChannel A is mostly on your side (outbound-heavy), while Channel B is mostly on\nthe remote side (inbound-heavy). You cannot send payments through Channel B\nbecause you have almost no local balance there. A rebalance can even them out.\n\n## Two Methods\n\nFiber supports two ways to rebalance:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/channel-rebalancing.md",
       "source": "channel-rebalancing.md"
     },
     {
-      "id": "chunk-1056",
+      "id": "chunk-1074",
       "title": "channel-rebalancing",
       "content": "### Method 1: Automatic Routing (`send_payment`)\n\nSet `target_pubkey` to your own node pubkey with `allow_self_payment: true`.\nThe routing algorithm automatically finds a circular path.\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"send_payment\",\n  \"params\": [\n    {\n      \"target_pubkey\": \"<your_own_pubkey>\",\n      \"amount\": \"0x5F5E100\",\n      \"keysend\": true,\n      \"allow_self_payment\": true\n    }\n  ],\n  \"id\": 1\n}\n```\n\n**Pros**: Simple, no need to manually plan the route.\n\n**Cons**: You cannot control which channels the payment flows through. Not\ncompatible with trampoline routing.\n\n### Method 2: Manual Routing (`build_router` + `send_payment_with_router`)\n\nThis gives you full control over the exact path. Use it when you want to target\nspecific channels for rebalancing.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/channel-rebalancing.md",
       "source": "channel-rebalancing.md"
     },
     {
-      "id": "chunk-1057",
+      "id": "chunk-1075",
       "title": "channel-rebalancing",
       "content": "**Step 1** — Build a circular route with `build_router`:\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"build_router\",\n  \"params\": [\n    {\n      \"amount\": \"0x5F5E100\",\n      \"hops_info\": [\n        { \"pubkey\": \"<peer_A_pubkey>\" },\n        { \"pubkey\": \"<peer_B_pubkey>\" },\n        { \"pubkey\": \"<your_own_pubkey>\" }\n      ]\n    }\n  ],\n  \"id\": 1\n}\n```\n\nThis returns a `router_hops` array describing the full route with fees and\nexpiry deltas.\n\n**Step 2** — Send the payment with the constructed route:\n\n```json\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"send_payment_with_router\",\n  \"params\": [\n    {\n      \"router\": \"<router_hops from step 1>\",\n      \"keysend\": true\n    }\n  ],\n  \"id\": 2\n}\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/channel-rebalancing.md",
       "source": "channel-rebalancing.md"
     },
     {
-      "id": "chunk-1058",
+      "id": "chunk-1076",
       "title": "channel-rebalancing",
       "content": "**Pros**: Full control over which channels are used. You can also pin specific\nchannels by providing `channel_outpoint` in `hops_info`.\n\n**Cons**: Requires you to know the network topology and plan the route.\n\n## Tips\n\n- Use `dry_run: true` first to verify the route is valid and check the fee\n  before actually sending.\n- The rebalance amount plus routing fees must not exceed your local balance in\n  the outbound channel.\n- Routing fees depend on the intermediate nodes' fee policies. You can set\n  `max_fee_amount` to cap the total fee.\n- After a successful rebalance, use `list_channels` to verify the updated\n  balances.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/channel-rebalancing.md",
       "source": "channel-rebalancing.md"
     },
     {
-      "id": "chunk-1059",
+      "id": "chunk-1077",
       "title": "README",
       "content": "# Development\n\n## Run 3 nodes with default balances and deploy contracts to the devchain\n\nBelow command automatically start 3 FNN and 1 ckb node.\nWhen we have not initialized the dev chain for ckb, this command will automatically do that.\n\n```\n./tests/nodes/start.sh\n```\n\nRunning above command with environment variable `REMOVE_OLD_STATE` to `y` will remove all old states.\ni.e.\n\n```\nREMOVE_OLD_STATE=y ./tests/nodes/start.sh\n```\n\nwill start nodes in a clean state. This is useful in case like database schema are changed in development environment.\n\n## (Re)Initialize a dev chain (optional)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/dev/README.md",
       "source": "dev/README.md"
     },
     {
-      "id": "chunk-1060",
+      "id": "chunk-1078",
       "title": "README",
       "content": "We can (re)initialize the dev chain to transfer some balances from the default dev chain account (corresponding to NODE3) and deploy contracts to it. This is normally not needed as above command automatically do that. `-f` parameter may be used to forcefully clean all old state and reinitialize the dev chain.\n\n```\n./tests/deploy/init-dev-chain.sh [-f]\n```\n\n## Run some simple tests to the dev chain\n\n```\ncd tests/bruno\nnpm exec -- @usebruno/cli run e2e/open-use-close-a-channel -r --env test\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/dev/README.md",
       "source": "dev/README.md"
     },
     {
-      "id": "chunk-1061",
+      "id": "chunk-1079",
       "title": "external-funding",
       "content": "# External Funding\n\n## Signing `unsigned_funding_tx` Externally\n\n`open_channel_with_external_funding` returns the negotiated `unsigned_funding_tx`.\nAt this point the transaction structure is frozen: external signers only need to sign\nthe CKB cells they contributed for funding, then submit the same transaction with only\nthe corresponding `witnesses` filled via `submit_signed_funding_tx`.\n\nDo not rebuild the transaction or modify `inputs`, `outputs`, `outputs_data`, or\n`cell_deps` after it is returned.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/external-funding.md",
       "source": "external-funding.md"
     },
     {
-      "id": "chunk-1062",
+      "id": "chunk-1080",
       "title": "external-funding",
       "content": "For Rust developers using secp256k1-sighash locks, refer to the development-only\n`sign_external_funding_tx` implementation for how to sign the transaction:\n[`crates/fiber-lib/src/rpc/dev.rs:296`](../crates/fiber-lib/src/rpc/dev.rs).\nThis helper only covers secp256k1 signing. It resolves previous outputs, groups\nmatching lock scripts, signs each script group, and writes the signature into\n`WitnessArgs.lock`.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/external-funding.md",
       "source": "external-funding.md"
     },
     {
-      "id": "chunk-1063",
+      "id": "chunk-1081",
       "title": "external-funding",
       "content": "For JavaScript developers, refer to the pinned `fiber-wallet` `@ckb-ccc/ccc`\nexample. The main signing flow is\n[`signFundingTx`](https://github.com/joii2020/fiber-wallet/blob/77decbbe17ef39f1e443015bae41e74e6dd3960d/apps/src/wallet/manager.ts#L553-L584),\nwith\n[`toCccTransaction`](https://github.com/joii2020/fiber-wallet/blob/77decbbe17ef39f1e443015bae41e74e6dd3960d/apps/src/wallet/transaction.ts#L25-L116)\nfor JSON-RPC to CCC conversion and\n[`withFundingTxWitnesses`](https://github.com/joii2020/fiber-wallet/blob/77decbbe17ef39f1e443015bae41e74e6dd3960d/apps/src/wallet/manager.ts#L293-L312)\nfor copying signed witnesses back to the original transaction. The example supports\nstandard CCC signers, OmniLock witness preparation\n([`prepareOmniLockWitness`](https://github.com/joii2020/fiber-wallet/blob/77decbbe17ef39f1e443015bae41e74e6dd3960d/apps/src/wallet/manager.ts#L60-L85)),\nand JoyID redirect signing\n([`prepareJoyIdSignTx`](https://github.com/joii2020/fiber-wallet/blob/77decbbe17ef39f1e443015bae41e74e6dd3960d/apps/src/wallet/manager.ts#L477-L515)).",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/external-funding.md",
       "source": "external-funding.md"
     },
     {
-      "id": "chunk-1064",
+      "id": "chunk-1082",
       "title": "fiber-node-wss",
       "content": "# Fiber Node Network Connection TLS Configuration Guide\n> Browsers cannot connect to P2P networks directly. Instead, they must connect to your node over WebSocket with TLS (wss://). To support this, you need to deploy a TLS proxy in front of your node that converts WSS traffic into standard TCP.\n\nBefore you begin, ensure the following:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1065",
+      "id": "chunk-1083",
       "title": "fiber-node-wss",
       "content": "- Your Fiber node is running and listening on its default P2P port (8228)\n- You own a domain name and can modify its DNS records (e.g., via Cloudflare, Namecheap, or Alibaba Cloud).\n- You have a valid TLS certificate for your domain (You can use a commercial provider like DigiCert or a free tool like Certbot.)\n- Your server has ports 80 and 443 open to the public.\n- Nginx is installed with the Stream module enabled, which will be used to forward encrypted WebSocket traffic to the Fiber node.\n\n## Install the Nginx Stream Module\n\n```\nsudo apt update\nsudo apt install -y build-essential libpcre3 libpcre3-dev zlib1g zlib1g-dev libssl-dev jq\n```\n\n```\ncd /opt/\nsudo wget https://nginx.org/download/nginx-1.24.0.tar.gz\nsudo tar -zxvf nginx-1.24.0.tar.gz\ncd nginx-1.24.0",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1066",
+      "id": "chunk-1084",
       "title": "fiber-node-wss",
       "content": "sudo ./configure \\\n  --prefix=/usr/local/nginx \\\n  --with-stream \\\n  --with-stream_ssl_module \\\n  --with-stream_ssl_preread_module \\\n  --with-http_ssl_module \\\n  --with-http_v2_module \\\n  --with-http_gzip_static_module \\\n  --with-http_stub_status_module \\\n  --with-http_realip_module \\\n  --with-pcre\n```\n\n```\nsudo make\nsudo make install\n```\n\n## Working Example of Nginx Config\n\nHere’s a working example that:\n\n- Routes TCP (P2P) and WSS traffic differently based on TLS version\n- Proxies WSS traffic to a separate internal port (8443)\n\nYou need to replace:\n\n- fiber.example.com with your domain\n- 8228 with your node’s P2P port\n- 443 with the external public port\n- TLS cert paths with your actual file paths\n\n```\n# Global settings\nuser www-data;\nworker_processes auto;\npid /run/nginx.pid;",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1067",
+      "id": "chunk-1085",
       "title": "fiber-node-wss",
       "content": "# Events\nevents {\n    worker_connections 768;\n}\n\n# ===================\n# Stream block (used for TCP/TLS protocol detection and routing)\n# ===================\nstream {\n    log_format stream_log '$remote_addr - $remote_port [$time_local] '\n                          'Protocol: $ssl_preread_protocol '\n                          'Status: $status '\n                          'Bytes_Sent: $bytes_sent '\n                          'Bytes_Received: $bytes_received '\n                          'Session_Time: $session_time '\n                          'Upstream: $upstream_addr';\n\n    # Map TLS version to upstream\n    map $ssl_preread_protocol $upstream {\n        default      backend_tcp;\n        \"TLSv1.2\"    backend_wss_http;\n        \"TLSv1.3\"    backend_wss_http;\n    }",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1068",
+      "id": "chunk-1086",
       "title": "fiber-node-wss",
       "content": "upstream backend_tcp {\n        server 127.0.0.1:8228;\n    }\n\n    upstream backend_wss_http {\n        server 127.0.0.1:8443;\n    }\n\n    server {\n        listen 443;\n        proxy_pass $upstream;\n        ssl_preread on;\n        access_log /var/log/nginx/stream_access.log stream_log;\n        error_log /var/log/nginx/stream_error.log;\n\n    }\n}\n\n# ===================\n# HTTP block (for WSS over HTTPS and Web services)\n# ===================\nhttp {\n    sendfile on;\n    tcp_nopush on;\n    tcp_nodelay on;\n    keepalive_timeout 65;\n    server_tokens off;\n    types_hash_max_size 2048;\n\n    client_max_body_size 10m;\n\n    include /usr/local/nginx/conf/mime.types;\n    default_type application/octet-stream;\n\n    ssl_protocols TLSv1.2 TLSv1.3;\n    ssl_prefer_server_ciphers on;",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1069",
+      "id": "chunk-1087",
       "title": "fiber-node-wss",
       "content": "access_log /var/log/nginx/access.log;\n    error_log /var/log/nginx/error.log;\n    gzip on;\n\n    # Server block for WSS proxy\n    server {\n        listen 8443 ssl;\n        server_name fiber.example.com;\n\n        ssl_certificate /usr/local/nginx/ssl/fullchain.pem;\n        ssl_certificate_key /usr/local/nginx/ssl/privkey.pem;\n        ssl_protocols TLSv1.2 TLSv1.3;\n\n        location / {\n            proxy_pass http://127.0.0.1:8228;\n            proxy_http_version 1.1;\n            proxy_set_header Upgrade $http_upgrade;\n            proxy_set_header Connection \"upgrade\";\n            proxy_set_header Host $host;\n            proxy_read_timeout 3600s;\n            proxy_send_timeout 3600s;\n        }\n    }\n}\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1070",
+      "id": "chunk-1088",
       "title": "fiber-node-wss",
       "content": "## Start nginx\n```\n/usr/local/nginx/sbin/nginx -t\n/usr/local/nginx/sbin/nginx\n# /usr/local/nginx/sbin/nginx -s reload\n```\n\n## Add Domain DNS Resolution\n\nAdd an A record for the domain fiber.example.com to your Fiber node's IP address in your domain registrar.\n\n## Connect to Your Node via WSS\n\n**Option A — Connect by explicit WSS address:**\nPrerequisites:\n\n- In your Fiber node's `config.yml`, add the WSS multiaddr to `announced_addrs` so that\n  browser/WASM clients can discover and connect to your node via the P2P graph:\n\n```yaml\nannounced_addrs:\n    - /ip4/<your-public-ip>/tcp/8228\n    - /dns4/fiber.example.com/tcp/443/wss\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1071",
+      "id": "chunk-1089",
       "title": "fiber-node-wss",
       "content": "```sh\ncurl -s -X POST http://127.0.0.1:8227 \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": 42,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"connect_peer\",\n    \"params\": [{ \"address\": \"/dns4/fiber.example.com/tcp/443/wss\" }]\n  }'\n```\n\n**Option B — Connect by pubkey (requires WSS address to be propagated via gossip):**\n\n- First, make sure you have completed the Update announced_addrs step and restarted your node so the WSS address has been broadcast to the network.\n\nGet your node's pubkey:\n\n```sh\ncurl -s -X POST http://127.0.0.1:8227 \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"id\": 42, \"jsonrpc\": \"2.0\", \"method\": \"node_info\", \"params\": []}' \\\n  | jq -r '.result.pubkey'\n```\n\nThen connect using the pubkey:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1072",
+      "id": "chunk-1090",
       "title": "fiber-node-wss",
       "content": "```sh\ncurl -s -X POST http://127.0.0.1:8227 \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": 42,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"connect_peer\",\n    \"params\": [{ \"pubkey\": \"<your-node-pubkey>\", \"addr_type\": \"wss\" }]\n  }'\n  ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/fiber-node-wss.md",
       "source": "fiber-node-wss.md"
     },
     {
-      "id": "chunk-1073",
+      "id": "chunk-1091",
       "title": "glossary",
       "content": "# Fiber Network Glossary\n\nSimple and non-technical explanations of key Fiber Network terminology.\n\n## Asset\nThe value unit that Fiber moves through channels. An asset can be the native CKB token or a user-defined token (UDT) on the Nervos CKB chain. Unless a specific asset type matters, references to \"assets\" in this glossary mean any Fiber-supported token.\n\n## Fiber Network (Lightning-style on CKB)\nThe \"Asset High-Speed Highway\" for the CKB ecosystem. While asset transfers usually wait for block confirmations on-chain, Fiber Network uses Lightning-style channels to move these assets through \"side lanes\" with near-instant speed and negligible fees. Final settlements are only reported back to the CKB mainnet when necessary.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1074",
+      "id": "chunk-1092",
       "title": "glossary",
       "content": "## Node\nAn \"Asset Transit Station.\" This can be your CKB wallet or a dedicated server. Nodes are the backbone of the fiber network, responsible for maintaining channels and ensuring that assets flow safely to their destinations.\n\n## Payment Channel\nA \"Private Conveyor Belt\" between two nodes. Both parties lock a certain amount of Cells (CKB's version of smart UTXOs) containing assets on the mainnet. Once open, you can slide balances back and forth instantly—like moving beads on an abacus—without touching the main blockchain.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1075",
+      "id": "chunk-1093",
       "title": "glossary",
       "content": "## Commitment Transaction\nA \"Latest Settlement Agreement.\" Every time the balance of assets changes in the channel, both parties sign a new agreement. It’s your safety net: if your partner disappears, you can submit this latest agreement to the CKB mainnet to reclaim your Cells and assets.\n\n## Gossip Protocol\nThe \"Status Broadcast.\" Since Fiber Network is decentralized, nodes \"gossip\" to share info: \"I have a channel open,\" or \"I support routing this specific asset.\" This lets nodes build a route map. Gossip shares channel presence and fees—not real-time balances—so a path found this way can still lack capacity.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1076",
+      "id": "chunk-1094",
       "title": "glossary",
       "content": "## Multi-hop Routing\nThe \"Asset Relay Race.\" You don’t need a direct channel with everyone. If you want to send assets to someone you aren't connected to, the network finds a path through intermediate nodes, \"hopping\" the assets from channel to channel until they reach the destination.\n\n## Onion Routing\nA \"Multi-Layered Privacy Wrap.\" When you send assets, the route is encrypted in layers. Each intermediate node only knows where to pass the \"package\" next, they don’t know where it started or where it’s finally going, keeping your financial activity private.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1077",
+      "id": "chunk-1095",
       "title": "glossary",
       "content": "## Preimage\nThe \"Digital Claim Ticket.\" This is a secret random string generated by the recipient. It acts as the only key that can unlock the payment. Whoever presents the correct Preimage according to the contract rules gets to claim the assets in the channel.\n\n## HTLC (Hashed Timelock Contract)\nA \"Timed Vault with a Passcode.\" The sender locks assets in a box with two rules: \"If you show the 'Claim Ticket' (Preimage) within a certain time, the assets are yours. If the timer runs out, the assets fly back to me.\" This ensures middlemen can’t run away with the money.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1078",
+      "id": "chunk-1096",
       "title": "glossary",
       "content": "## PTLC (Point Timelock Contract)\nThe \"Mathematical Upgrade\" to HTLC. In a PTLC, the lock is a curve point (like a public key) rather than a hash, so the secret acts like a private key. This removes the repeated-hash linkage, improving privacy and enabling cleaner multi-path/swap designs. PTLC support is a planned direction; today Fiber still runs on hash-based TLC/HTLC flows.\n\n## Invoice\nA \"Digital Bill\" or QR code. When you want to receive a payment, you generate an invoice. It contains the asset type, the amount, an expiry, and a lock derived from a secret (a payment hash today, or a point in a PTLC future). The sender scans it, and Fiber Network automatically finds the best path to pay you.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1079",
+      "id": "chunk-1097",
       "title": "glossary",
       "content": "## Routing Fee\nThe \"Asset Handling Fee.\" Intermediate nodes lock up their own liquidity to forward your payment. The payer covers a small fee (in the asset being moved) as compensation.\n\n## Watchtower\nYour \"Asset Bodyguard.\" Since channel asset states are stored off-chain, a dishonest partner might try to broadcast an \"old agreement\" to steal funds while you are offline. A Watchtower monitors the CKB chain 24/7 and automatically intercepts any cheating attempts, punishing the attacker.\n\n## Node Identifiers: Pubkey and Peer ID\n\nFiber uses two identity forms:\n\n- **Pubkey**: a 33-byte compressed secp256k1 public key (66-char hex), e.g. `\"02ab1234...\"`.\n- **Peer ID**: a base58 transport identifier derived from the pubkey.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1080",
+      "id": "chunk-1098",
       "title": "glossary",
       "content": "For RPC usage, treat **`pubkey` as the standard node identity**.  \n`Peer ID` is mainly an internal/P2P transport identifier and is generally not what you pass around in normal RPC workflows.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/glossary.md",
       "source": "glossary.md"
     },
     {
-      "id": "chunk-1081",
+      "id": "chunk-1099",
       "title": "light-paper-cn",
       "content": "# Fiber Network：基于 CKB 的闪电网络\n\n## 概述\n\nFiber Network 是一个基于 Nervos CKB 和链外通道构建的下一代公共闪电网络，可以为 RGB++ 资产提供快速、低成本和去中⼼化的多币种⽀付和点对点交易。\n\n## 背景\n\n### 区块链技术的发展与挑战\n\n区块链技术自比特币问世以来，经历了迅猛的发展。从最初的简单支付功能，逐步扩展到智能合约、去中心化金融（DeFi）、非同质化代币（NFT）等广泛的应用领域。尽管区块链技术在安全性、透明度和去中心化方面具备显著优势，但其在扩展性和交易速度方面面临诸多挑战。\n\n1. 扩展性问题：传统区块链如比特币和以太坊在交易吞吐量上存在显著瓶颈。比特币受区块大小和 10 分钟区块生成时间的限制，每秒最多处理约 7 笔交易。以太坊虽然有所改进，但 TPS（每秒交易量）仍远低于传统支付网络。\n\n2. 高昂的交易费用：随着网络拥堵的加剧，交易费用显著上升。例如，以太坊网络上高峰期的 Gas 费用可能高于交易金额本身，这严重影响了用户体验并降低了小额支付的可行性。\n\n3. 交易确认时间长：在传统区块链网络中，交易需要等待多个区块确认才能被视为最终确认。这一过程可能耗时数分钟到数小时，不适用于即时支付的应用场景。\n\nNervos CKB 虽然在性能以及确认时间上有所改进，但仍然需要进一步提高交易速度和降低交易成本，以满足小额支付和即时支付的需求。\n\n### 闪电网络的启示\n\n闪电网络（Lightning Network）作为比特币网络的二层扩展解决方案，通过链下交易和支付通道技术，成功实现了快速、低成本的微支付。其核心理念包括：\n\n1. 支付通道：用户在链上创建支付通道，通道开启后，双方可以无限次地进行链下交易，只有在通道关闭时才进行链上结算。这显著减少了链上交易数量，提升了交易速度，降低了交易费用。",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper-cn.md",
       "source": "light-paper-cn.md"
     },
     {
-      "id": "chunk-1082",
+      "id": "chunk-1100",
       "title": "light-paper-cn",
       "content": "2. 哈希时间锁合约（HTLC）：通过 HTLC 技术闪电网络可以确保资金的安全转移，避免交易对手风险。即使在链下交易失败的情况下，用户也能通过链上合约获得资金保障。\n\n3. 路由机制：闪电网络使用多跳路由，使得用户不需要与收款方开设直接通道即可完成支付，因此提高了网络的灵活性和可用性。\n\n## Nervos CKB 的优势\n\nNervos CKB 是一个专注于通用性和安全性的区块链平台。其独特的设计使其在解决区块链扩展性和互操作性问题上具备独特优势：\n\n1. 共识机制：基于 [NC-Max](https://eprint.iacr.org/2020/1101) 共识协议，同时在结合了工作量证明（PoW）和状态租赁机制，确保网络安全性和资源利用的有效性。\n\n2. 强大的智能合约模型：CKB 独有的 Cell 模型和 RISC-V 指令集虚拟机大大增强了 UTXO 模型的能力，不仅支持图灵完备的智能合约，还能轻松实现抽象账户以及 covenant 等特性，为去中心化应用提供了更灵活的可编程性，以及更好的互操作性和扩展性。\n\n3. 经济模型：CKB 的经济模型鼓励长期持有和合理使用网络资源，为去中心化应用，开发者和用户提供了安全可持续的去中心化生态环境。\n\n## Fiber Network 项目的意义\n\n通过在 Nervos CKB 上构建链外通道，我们希望借鉴闪电网络的成功经验，并结合 CKB 的技术优势，构建一个快速、低成本和去中心化的多资产实时支付交换网络。具体而言：\n\n1. 解决扩展性问题：通过链下支付通道和多跳路由技术，Fiber Network 可以实现高吞吐量的交易处理，从而满足大规模用户的需求。\n\n2. 降低交易成本：减少链上交易频次，降低用户的交易费用，使得小额支付变得可行和高效。",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper-cn.md",
       "source": "light-paper-cn.md"
     },
     {
-      "id": "chunk-1083",
+      "id": "chunk-1101",
       "title": "light-paper-cn",
       "content": "3. 提高交易速度：通过即时确认的链下交易，实现秒级支付确认体验，适用于各种即时支付场景。\n\n4. 多资产支持：支持多种数字资产的支付，为用户提供更广泛的支付选择。\n\n5. 支持网络互操作: 支持与比特币闪电网络的互操作，为跨链支付和资产转移提供支持。\n\n## 架构设计\n\n### 总体架构\n\nFiber Network 总体架构包括以下核心模块：\n\n1. 链下支付通道（Fiber Channels）\n\n2. 链上合约（HTLC）\n\n3. 多跳路由（Multi-Hop Routing）\n\n4. 监控服务（Watchtower Service）\n\n### 链下支付通道\n\n链下支付通道是 Fiber Network 的核心，通过它可以实现多次链下交易，仅在通道关闭时进行链上结算。这种机制显著减少了链上交易的数量，提高了交易速度和降低了交易费用。\n\n大致的工作流程如下：\n\n1. 通道创建：双方用户在链上创建支付通道，锁定一定数量的 CKB 或者 RGB++ 资产。\n\n2. 链下交易：在通道开启期间，双方可以任意次进行链下交易，每次交易都更新通道状态，但不需要立即广播到链上。\n\n3. 通道关闭：当任一方决定关闭通道时，将最后的通道状态广播到链上进行结算，确保双方的最终余额得到确认。\n\n具体的消息交互格式可以参考 [Fiber Network P2P Message Protocol](./specs/p2p-message.md)。\n\n### 链上合约\n\n目前我们采用哈希时间锁合约（HTLC） 来确保链下交易的安全性并兼容闪电网络。通过它可以避免交易对手风险，确保即使在链下交易失败的情况下，用户也能通过链上合约获得资金保障。\n\n大致的工作流程如下：\n\n1. 交易发起：支付发起方创建一个带有哈希锁定和时间锁定条件的交易，锁定一定数量的 CKB。",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper-cn.md",
       "source": "light-paper-cn.md"
     },
     {
-      "id": "chunk-1084",
+      "id": "chunk-1102",
       "title": "light-paper-cn",
       "content": "2. 哈希验证：支付接收方必须在规定时间内提供正确的哈希原象，才能解锁交易，完成资金转移。\n\n3. 超时退款：如果接收方在规定时间内未能提供正确的哈希原象，交易将自动解锁并退款给支付发起方。\n\n得益于 CKB 的图灵完备性，我们可以实现更灵活以及更安全的链上合约。之后会进一步扩展合约的功能，比如引入基于版本号的撤销机制和更安全的 Point Time-Locked Contracts。\n\n### 多跳路由\n\n多跳路由技术允许用户在没有和对方直接建立支付通道的情况下，通过多个中间节点完成支付。这种机制增强了网络的灵活性和覆盖范围。\n\n工作流程：\n\n1. 路径发现：支付发起方通过路由模块发现从自身到支付接收方的最优路径。\n\n2. 路径锁定：在路径上的每个节点都创建相应的 HTLC 合约，确保资金安全转移。\n\n3. 支付完成：支付接收方解锁 HTLC，资金依次转移到路径上的各个节点。\n\n同时我们也会在这里用HTLC合约实现跨链的支付，通过 cross-chain hub service 的方式来支持与闪电网络的互操作，具体可以参考 [Payment Channel Cross-Chain Protocol with HTLC](./specs/cross-chain-htlc.md)。\n\n### 监控服务\n\n监控服务是 Fiber Network 的重要组成部分，它负责监控链下支付通道的状态，确保通道的安全性和资金的安全。功能和作用如下：\n\n1. 通道监控：实时监控所有参与用户的支付通道状态，包括通道创建、更新和关闭的过程。\n\n2. 异常检测：检测通道中的异常活动，如恶意用户试图以旧状态关闭通道或企图双花攻击。\n\n3. 主动响应：在检测到异常时，及时向区块链网络广播最新的通道状态，防止恶意行为导致的资金损失。\n\n## 当前进展和计划",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper-cn.md",
       "source": "light-paper-cn.md"
     },
     {
-      "id": "chunk-1085",
+      "id": "chunk-1103",
       "title": "light-paper-cn",
       "content": "目前我们已经完成一个 Fiber Network 的原型，实现了两个节点之间的通道的创建、更新和关闭的基本功能，同时也验证了和比特币闪电网络做跨链的功能。 项目代码可在这 2 个 GitHub 仓库中找到：\n\n1. https://github.com/nervosnetwork/fiber\n\n2. https://github.com/nervosnetwork/fiber-scripts\n\n接下来的工作计划准备完成多跳路由和监控服务，以及完善 RPC 接口和 SDK，使得更多的开发者可以方便的接入 Fiber Network。\n\n多跳路由协议基于 Dijkstra 算法来搜索支付路径，以此降低路由费用，并提高多跳路径支付成功率。 在 Fiber Network 上线运行之后， 我们会根据网络流量和运行情况优化路由算法， 预计提供 2～3 种路径搜索策略，以适应用户不同的路由偏好和需求。Fiber Network 还将引入多路径支付策略，将较大的支付额分成多份，每一份由不同的路径传送，进一步增加支付成功概率。\n\n监控服务将由 Fiber Network 中的一些节点提供，他们会保持在线状态来关注网络中的异常情况，以帮助保护通道中的资产。监控服务还将追踪 cross-chain hub service，这样即使用户在一段时间内离线，监控服务也能确保与闪电网络的交换能成功进行。\n\n此外，我们还将考虑在 Fiber Network 中加入更多功能，比如利用 CKB 的可编程性实现隐私保护算法，并基于此优化路由算法和监控服务，保护用户支付信息的安全和隐私。",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper-cn.md",
       "source": "light-paper-cn.md"
     },
     {
-      "id": "chunk-1086",
+      "id": "chunk-1104",
       "title": "light-paper",
       "content": "# Fiber Network: A Lightning Network Based on CKB\n\n## Overview\n\nFiber Network is a next-generation, common lightning network built on Nervos CKB and off-chain channels. It is designed to provide fast, low-cost, and decentralized multi-token payments and peer-to-peer transactions for RGB++ assets.\n\n## Background\n\n### Evolution and Challenges of Blockchain Technology\n\nBlockchain technology has undergone rapid evolution since the inception of Bitcoin. Initially designed for simple payments, it has gradually expanded into various domains such as smart contracts, decentralized finance (DeFi), and non-fungible tokens (NFTs). Despite its significant advantages in security, transparency, and decentralization, blockchain technology faces several challenges in scalability and transaction speed.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1087",
+      "id": "chunk-1105",
       "title": "light-paper",
       "content": "1. Scalability. Traditional blockchains like Bitcoin and Ethereum face significant bottlenecks in transaction throughput. Due to Bitcoin's block size limit and 10-minute block generation time, its network can only process about 7 transactions per second; Ethereum, despite improvements, still has a transaction processing capacity far below traditional payment networks.\n\n2. High transaction fees. As network congestion increases, transaction fees rise significantly. For instance, gas fees on the Ethereum network during peak times may exceed the transaction amount itself, severely affecting user experience and reducing the feasibility of micropayments.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1088",
+      "id": "chunk-1106",
       "title": "light-paper",
       "content": "3. Long transaction confirmation times. In traditional blockchain networks, transactions need to wait for multiple block confirmations to be considered final. This process can take minutes to hours, making it unsuitable for instant payment scenarios.\n\nAlthough Nervos CKB has made improvements in terms of performance and confirmation times, it still needs to further increase transaction speed and reduce transaction costs to meet the demands of micropayments and instant payments.\n\n### Inspiration from the Lightning Network\n\nThe Lightning Network, a layer 2 scaling solution for the Bitcoin network, has successfully achieved fast, low-cost micropayments through off-chain transactions and payment channels. Its core concepts include:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1089",
+      "id": "chunk-1107",
       "title": "light-paper",
       "content": "1. Payment channels: Users create payment channels on-chain. Once a channel is opened, both parties can conduct unlimited off-chain transactions, only settling on-chain when the channel is closed. This significantly reduces the number of on-chain transactions, improves transaction speed, and lowers transaction fees.\n\n2. Hash Time-Locked Contracts (HTLC): Through HTLCs, the Lightning Network ensures secure fund transfers, mitigating counterparty risk. Even if off-chain transactions fail, users can still secure their funds through on-chain contracts.\n\n3. Routing mechanism: The Lightning Network uses multi-hop routing, allowing users to complete payments without opening direct channels with recipients, thus enhancing network flexibility and usability.\n\n## Advantages of Nervos CKB",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1090",
+      "id": "chunk-1108",
       "title": "light-paper",
       "content": "Nervos CKB is a blockchain platform focused on versatility and security. Its unique design offers distinct advantages in addressing blockchain scalability and interoperability issues:\n\n1. Consensus mechanism: Based on the [NC-Max](https://eprint.iacr.org/2020/1101) consensus protocol, it combines Proof of Work (PoW) with state rent mechanisms, ensuring network security and effective resource utilization.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1091",
+      "id": "chunk-1109",
       "title": "light-paper",
       "content": "2. Powerful smart contract capabilities: CKB's unique Cell model and RISC-V instruction set virtual machine significantly enhance the capabilities of the UTXO model. This not only supports Turing-complete smart contracts but also easily implements features such as account abstraction and covenants, providing more flexible programmability, better interoperability, and scalability for decentralized applications.\n\n3. Tokenomics: CKB's tokenomics encourages long-term holding and rational use of network resources, providing a secure and sustainable decentralized environment for applications, developers, and users.\n\n## Significance of the Fiber Network Project",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1092",
+      "id": "chunk-1110",
       "title": "light-paper",
       "content": "By building off-chain channels on Nervos CKB, we aim to combine the successful experience of the Lightning Network with CKB's technical advantages to create a fast, low-cost, and decentralized multi-asset real-time payment network. Specifically:\n\n1. Solving scalability issues: Through off-chain payment channels and multi-hop routing, Fiber Network can achieve high-throughput transaction processing, meeting the needs of large-scale users.\n\n2. Reducing transaction costs: By reducing the frequency of on-chain transactions, it lowers transaction fees, making micropayments feasible and efficient.\n\n3. Improving transaction speed: The instant confirmation of off-chain transactions provides a split second payment confirmation experience suitable for various instant payment scenarios.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1093",
+      "id": "chunk-1111",
       "title": "light-paper",
       "content": "4. Multi-asset support: Fiber Network supports payments in a variety of digital assets, offering users a broader range of payment options.\n\n5. Interoperability: Fiber Network supports interoperability with the Bitcoin Lightning Network, providing support for cross-chain payments and asset transfers.\n\n## Architecture Design\n\n### Overall Architecture\n\nThe overall architecture of Fiber Network includes the following core modules:\n\n1. Off-Chain Payment Channels (Fiber Channels)\n\n2. On-Chain Contracts (HTLC)\n\n3. Multi-Hop Routing\n\n4. Watchtower Service\n\n### Off-chain Payment Channels",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1094",
+      "id": "chunk-1112",
       "title": "light-paper",
       "content": "Off-chain payment channels are the core of Fiber Network, enabling multiple off-chain transactions with on-chain settlement only when the channel is closed. This mechanism significantly reduces the number of on-chain transactions, improves transaction speed, and lowers transaction fees.\nThe general workflow is as follows:\n\n1. Opening a Channel: Two parties open a payment channel on-chain, locking a certain amount of CKB or RGB++ assets.\n\n2. Off-chain transactions: When the channel is open, both parties can conduct an unlimited number of off-chain transactions, updating the channel state with each transaction without immediate broadcasting to the chain.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1095",
+      "id": "chunk-1113",
       "title": "light-paper",
       "content": "3. Closing the Channel: When either party decides to close the channel, the final channel state is broadcasted on-chain for settlement, ensuring the final balances of both parties are confirmed.\n\nThe message interaction format can be referenced in the [Fiber Network P2P Message Protocol](./specs/p2p-message.md).\n\n### On-Chain Contracts\n\nCurrently, we use Hash Time-Locked Contracts (HTLC) to ensure the security of off-chain transactions and maintain compatibility with the Lightning Network. This mitigates counterparty risk, ensuring that even if off-chain transactions fail, users can still secure their funds through on-chain contracts.\n\nThe general workflow is as follows:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1096",
+      "id": "chunk-1114",
       "title": "light-paper",
       "content": "1. Transaction initiation: The payment initiator creates a transaction with hashlock and timelock, and locks a certain amount of CKB.\n\n2. Hash verification: The payment recipient must provide the correct hash preimage within the specified time to unlock the transaction and complete the fund transfer.\n\n3. Timeout refund: If the recipient fails to provide the correct hash preimage within the specified time, the transaction will automatically unlock and refund to the payment initiator.\n\nThanks to CKB's Turing completeness, we can implement more flexible and secure on-chain contracts. We will further expand the contract's functionality in the future, such as introducing a version-based revocation mechanism and more secure Point Time-Locked Contracts.\n\n### Multi-hop Routing",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1097",
+      "id": "chunk-1115",
       "title": "light-paper",
       "content": "Multi-hop routing allows users to complete payments through multiple intermediate nodes without establishing direct payment channels with the counterparty. This mechanism enhances the network's flexibility and coverage.\n\nThe general workflow is as follows:\n\n1. Path discovery: The payment initiator discovers the optimal path from themselves to the payment recipient through the routing module.\n\n2. Path locking: Each node on the path creates corresponding HTLC contracts, ensuring secure fund transfers.\n\n3. Payment completion: The payment recipient unlocks the HTLC, and funds are transferred sequentially to each node on the path.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1098",
+      "id": "chunk-1116",
       "title": "light-paper",
       "content": "We will also implement cross-chain payments here using HTLC contracts, supporting interoperability with the Lightning Network through the cross-chain hub service. For more details, please refer to [Payment Channel Cross-Chain Protocol with HTLC](./specs/cross-chain-htlc.md).\n\n### Watchtower Service\n\nThe watchtower service is an essential component of Fiber Network, responsible for monitoring the state of off-chain payment channels and ensuring the security of channels and funds. Its functions and roles are as follows:\n\n1. Channel monitoring: Real-time monitoring of the payment channel state of all participating users, including opening, updating, and closing channels.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1099",
+      "id": "chunk-1117",
       "title": "light-paper",
       "content": "2. Anomaly detection: Detecting abnormal activities in channels, such as malicious users attempting to close channels with old states or double-spending attacks.\n\n3. Proactive response: When anomalies are detected, promptly broadcasting the latest channel state to the blockchain network to prevent fund losses due to malicious behavior.\n\n## Current Progress and Future Plans\n\nWe have currently completed a prototype of Fiber Network, implementing basic functions of opening, updating, and closing channels between two nodes, and also verifying cross-chain functionality with the Bitcoin Lightning Network. The project code can be found in the following GitHub repositories:\n\n1. https://github.com/nervosnetwork/fiber\n\n2. https://github.com/nervosnetwork/fiber-scripts",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1100",
+      "id": "chunk-1118",
       "title": "light-paper",
       "content": "Our next steps include completing multi-hop routing and watchtower services, as well as improving the RPC interface and SDK to facilitate easier access for developers to Fiber Network.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1101",
+      "id": "chunk-1119",
       "title": "light-paper",
       "content": "The multi-hop routing protocol is based on the Dijkstra algorithm to search for payment paths, thereby reducing routing fees and improving the success rate of multi-hop path payments. After Fiber Network goes live, we will optimize the routing algorithm based on network traffic and operational conditions. We expect to provide 2 or 3 path search strategies to adapt to users' different routing preferences and needs. Fiber Network will also introduce multi-path payment strategies, dividing larger payment amounts into multiple parts, each transmitted through different paths, further increasing the probability of successful payments.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1102",
+      "id": "chunk-1120",
       "title": "light-paper",
       "content": "The watchtower service will be provided by some nodes in Fiber Network. These nodes will stay online, monitor abnormal situations in the network, and help protect assets in channels. The monitoring service will also track the cross-chain hub service. Even if users are offline for a period, the monitoring service can ensure successful exchanges with the Lightning Network.\n\nAdditionally, we will consider adding more features to Fiber Network, such as implementing privacy protection algorithms leveraging CKB's programmability, and based on this, optimizing routing algorithms and watchtower services to enhance the security and privacy of users’ payment information.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/light-paper.md",
       "source": "light-paper.md"
     },
     {
-      "id": "chunk-1103",
+      "id": "chunk-1121",
       "title": "network-nodes",
       "content": "# Fiber Network Nodes\n\n> **Important:** Bootnodes are used for **peer discovery only** and cannot be used to create payment channels. To open/create a payment channel, you must connect to a **public node**.\n\n**Why this document only lists pubkeys, not IP addresses:** Since `v0.8.0`, Fiber RPCs identify peers by **pubkey** rather than `peer_id`. In practice, once your node has learned a peer's address from gossip (or from saved peer state), `connect_peer` can resolve the address from the pubkey automatically. Since node IPs may change over time while the pubkey stays stable, only the stable pubkey is listed here.\n\n**More nodes:** [https://dashboard.fiber.channel/nodes](https://dashboard.fiber.channel/nodes)\n\n## Mainnet\n\n### Public Nodes (can create channels)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/network-nodes.md",
       "source": "network-nodes.md"
     },
     {
-      "id": "chunk-1104",
+      "id": "chunk-1122",
       "title": "network-nodes",
       "content": "The public nodes' CKB addresses do not hold any USDI yet, so UDT channels cannot be created at this time.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/network-nodes.md",
       "source": "network-nodes.md"
     },
     {
-      "id": "chunk-1105",
+      "id": "chunk-1123",
       "title": "network-nodes",
       "content": "| Name | Pubkey | CKB Address | open_channel_auto_accept_min_ckb_funding_amount | auto_accept_channel_ckb_funding_amount | UDT: USDI script | UDT: USDI auto_accept_amount |\n|------|--------|-------------|--------------------------------------------------|----------------------------------------|-------------------|-------------------------------|\n| fiber-mainnet-public-ca | `03a8d7da8d0934363dbc17f52c872e8d833016415266eabb3527439c5dd17adc6b` | `ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdjsydf39sklhfvtfnk57vvd7d2vn4kxwqpr3prn` | `49900000000` (≥ 499 CKB auto-accepted; 99 CKB collateral) | `25000000000` (250 CKB inbound liquidity) | code_hash: `0xbfa35a9c38a676682b65ade8f02be164d48632281477e36f8dc2f41f79e56bfc`, hash_type: `type`, args: `0xd591ebdc69626647e056e13345fd830c8b876bb06aa07ba610479eb77153ea9f` | `10000000` (≥ 0.1 USDI auto-accepted) |\n| fiber-mainnet-public-tokyo | `033a69e5be369dab43aefa96fa729d83c571ccb066f312136c6ab2d354fcc028f9` | `ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqv47n6dc9ay34npwktvlpp5huzjvd07t4qhspqyz` | `49900000000` (≥ 499 CKB auto-accepted; 99 CKB collateral) | `25000000000` (250 CKB inbound liquidity) | code_hash: `0xbfa35a9c38a676682b65ade8f02be164d48632281477e36f8dc2f41f79e56bfc`, hash_type: `type`, args: `0xd591ebdc69626647e056e13345fd830c8b876bb06aa07ba610479eb77153ea9f` | `10000000` (≥ 0.1 USDI auto-accepted) |",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/network-nodes.md",
       "source": "network-nodes.md"
     },
     {
-      "id": "chunk-1106",
+      "id": "chunk-1124",
       "title": "network-nodes",
       "content": "## Testnet\n\n### Public Nodes (can create channels)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/network-nodes.md",
       "source": "network-nodes.md"
     },
     {
-      "id": "chunk-1107",
+      "id": "chunk-1125",
       "title": "network-nodes",
       "content": "| Name | Pubkey | CKB Address | open_channel_auto_accept_min_ckb_funding_amount | auto_accept_channel_ckb_funding_amount | UDT: RUSD script | UDT: RUSD auto_accept_amount |\n|------|--------|-------------|--------------------------------------------------|----------------------------------------|-------------------|-------------------------------|\n| fiber-testnet-public-bottle | `02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71` | `ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfy4w0gqjsm0ulnq0l4ft6hu6spztrj72sjtcnx4` | `49900000000` (≥ 499 CKB auto-accepted; 99 CKB collateral) | `25000000000` (250 CKB inbound liquidity) | code_hash: `0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a`, hash_type: `type`, args: `0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b` | `2000000000` (≥ 20 RUSD auto-accepted) |\n| fiber-testnet-public-bracer | `0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc` | `ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqwgkulmcyxtv2vgcmgatupg2r02k8n4mjcmm9f5m` | `49900000000` (≥ 499 CKB auto-accepted; 99 CKB collateral) | `25000000000` (250 CKB inbound liquidity) | code_hash: `0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a`, hash_type: `type`, args: `0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b` | `2000000000` (≥ 20 RUSD auto-accepted) |",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/network-nodes.md",
       "source": "network-nodes.md"
     },
     {
-      "id": "chunk-1108",
+      "id": "chunk-1126",
       "title": "README",
       "content": "# Developing Notes\n\nThe notes presented in this directory are intended to group multiple related docs into a\nmore readable and more maintainable way. Below is a few use cases for these notes.\n\n- Explaining some concepts across multiple source code locations.\n- Giving an overview of some historical background on implementation.\n\nThis is inspired by the notes in GHC source code. See [The Notes of GHC](https://www.stackbuilders.com/blog/the-notes-of-ghc/).",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/README.md",
       "source": "notes/README.md"
     },
     {
-      "id": "chunk-1109",
+      "id": "chunk-1127",
       "title": "backup-guide",
       "content": "# Fiber Node Backup Guide\n\nThis guide explains how to securely back up Fiber node data to safeguard funds, maintain node identity, and ensure smooth migration or upgrades. **Never store plaintext private keys**, as they risk theft if exposed.\n\n## Table of Contents\n\n1. [Why Back Up?](#1-why-back-up)\n2. [Backing Up Node Data](#2-backing-up-node-data)\n3. [Restoring Node Data](#3-restoring-node-data)\n4. [Handling Forgotten Passwords](#4-handling-forgotten-passwords)\n\n## 1. Why Back Up?",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/backup-guide.md",
       "source": "notes/backup-guide.md"
     },
     {
-      "id": "chunk-1110",
+      "id": "chunk-1128",
       "title": "backup-guide",
       "content": "Backups protect:\n- **Funds**: The encrypted private key (`ckb/key`) and its password (`FIBER_SECRET_KEY_PASSWORD`) are critical for accessing funds. Losing either makes funds unrecoverable.\n- **Node Identity**: The network ID key (`fiber/sk`) allows other nodes to recognize your node. Losing it disrupts network communication.\n\n**Warning**: Always stop the node before backing up to prevent data corruption, which could cause errors or loss of funds.\n\n## 2. Backing Up Node Data\n\nBack up the entire node directory (`fiber-dir`), which includes:\n- `ckb/key` (encrypted private key)\n- `fiber/sk` (network ID key)\n- `fiber/store` (database files)\n- `config.yml` (configuration)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/backup-guide.md",
       "source": "notes/backup-guide.md"
     },
     {
-      "id": "chunk-1111",
+      "id": "chunk-1129",
       "title": "backup-guide",
       "content": "**Steps**:\n1. **Stop the Node**:\n   ```bash\n   # Check for running node processes\n   ps aux | grep fnn\n   # Example output: ckb 3585187 0.7 2.4 756932 194052 ? Sl May07 71:52 ./fnn -c ./fiber-dir/config.yml -d ./fiber-dir\n   # Terminate it (replace 3585187 with your process ID)\n   kill 3585187\n   ```\n2. **Create Backup**:\n   ```bash\n   tar -zcvf fiber-dir.tar.gz fiber-dir\n   ```\n3. **Store Securely**: Save `fiber-dir.tar.gz` and the `FIBER_SECRET_KEY_PASSWORD` in an offline, encrypted environment (e.g., an encrypted drive or password manager).\n\n**Note**: A future update will allow backups without stopping the node. Check release notes for updates.\n\n## 3. Restoring Node Data",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/backup-guide.md",
       "source": "notes/backup-guide.md"
     },
     {
-      "id": "chunk-1112",
+      "id": "chunk-1130",
       "title": "backup-guide",
       "content": "**Steps**:\n1. **Extract Backup**:\n   ```bash\n   tar -zxvf fiber-dir.tar.gz\n   ```\n2. **Start Node**:\n   ```bash\n   FIBER_SECRET_KEY_PASSWORD='YOUR_PASSWORD' ./fnn -c ./fiber-dir/config.yml -d ./fiber-dir\n   ```\n\n**Warning**: Using the wrong password will trigger a startup error (`Secret key file error: decryption failed`). Double-check the password before starting.\n\n## 4. Handling Forgotten Passwords\n\nIf you lose the `FIBER_SECRET_KEY_PASSWORD` but have a plaintext private key (not recommended), you can reset the password.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/backup-guide.md",
       "source": "notes/backup-guide.md"
     },
     {
-      "id": "chunk-1113",
+      "id": "chunk-1131",
       "title": "backup-guide",
       "content": "**Steps**:\n1. **Extract Backup**:\n   ```bash\n   tar -zxvf fiber-dir.tar.gz\n   ```\n2. **Remove Encrypted Key**:\n   ```bash\n   rm -rf fiber-dir/ckb\n   ```\n3. **Add Plaintext Key**:\n   ```bash\n   mkdir fiber-dir/ckb\n   echo \"YOUR_PLAINTEXT_KEY\" > fiber-dir/ckb/key\n   ```\n4. **Start Node with New Password**:\n   ```bash\n   FIBER_SECRET_KEY_PASSWORD='NEW_PASSWORD' ./fnn -c ./fiber-dir/config.yml -d ./fiber-dir\n   ```\n5. **Secure the Key**: The `ckb/key` file will be re-encrypted with the new password. Store the new password securely.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/backup-guide.md",
       "source": "notes/backup-guide.md"
     },
     {
-      "id": "chunk-1114",
+      "id": "chunk-1132",
       "title": "break-change-migrate",
       "content": "# Fiber Breaking Change Migration Guide\n\n## Why\n\nFiber's got some big updates, including changes to the database schema that don't play nice with older versions. We introduced our first breaking change to roll out the cool new basic MPP feature and some security patches.\n\nTo jump to the latest Fiber version, you'll need to follow a straightforward migration process to keep your data safe and your system humming.\n\n## Prerequisites\n\nBefore starting the migration process, ensure you have:\n\n- [ ] Fiber node is running and accessible\n- [ ] Sufficient time to close all channels (can take several minutes)\n- [ ] Network connectivity for possible cooperative channel closures\n\n## Backup Old Database",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1115",
+      "id": "chunk-1133",
       "title": "break-change-migrate",
       "content": "Creating a backup is crucial before starting the migration process. For backup steps, please refer to the [backup-guide](https://github.com/nervosnetwork/fiber/blob/develop/docs/notes/backup-guide.md#2-backing-up-node-data).\n\nThe simplest way to create a backup is to make a copy of the Fiber running directory:\n\nStop the Node. Suppose `fiber` is running based on directory `fiber-dir`:\n```bash\n# Check for running node processes\nps aux | grep fnn\n# Example output: ckb 3585187 0.7 2.4 756932 194052 ? Sl May07 71:52 ./fnn -c ./fiber-dir/config.yml -d ./fiber-dir\n# Terminate it (replace 3585187 with your process ID)\nkill 3585187\n```\n\nCreate Backup:\n```bash\ntar -zcvf backup-fiber-dir.tar.gz fiber-dir\n```\n\n## Close All Channels",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1116",
+      "id": "chunk-1134",
       "title": "break-change-migrate",
       "content": "We’re clearing out the old database, but don’t worry—we’ll make sure your funds are safe!To free up funds locked in open channels, we’ll first try a friendly (cooperative) shutdown, which needs the other party to be online. If that doesn’t work, we’ll switch to a forceful shutdown.\n\n### 1. List Active Channels\n\n```bash\n# Check all channels from the Fiber node\n\ncurl -X POST http://127.0.0.1:8228 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Accept: application/json\" \\\n  -d '{\"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{}]}' | jq '.result.channels'\n```\n\nThis will show all your active channels (closed ones won’t appear).\n\n### 2. Cooperative Shutdown Channel",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1117",
+      "id": "chunk-1135",
       "title": "break-change-migrate",
       "content": "Let’s try closing each active channel nicely. We’re using `default_funding_lock_script` as the close script here:\n\n```bash\n#!/bin/bash\ndefault_funding_lock_script=$(curl -s -X POST http://127.0.0.1:8228 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Accept: application/json\" \\\n  -d '{\"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"node_info\", \"params\": [{}]}' | jq -r '.result.default_funding_lock_script')\n\ncode_hash=$(echo \"$default_funding_lock_script\" | jq -r '.code_hash')\nhash_type=$(echo \"$default_funding_lock_script\" | jq -r '.hash_type')\nscript_args=$(echo \"$default_funding_lock_script\" | jq -r '.args')",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1118",
+      "id": "chunk-1136",
       "title": "break-change-migrate",
       "content": "# First, get all channel IDs as a string\nchannel_ids=$(curl -s -X POST http://127.0.0.1:8228 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Accept: application/json\" \\\n  -d '{\"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{}]}' \\\n  | jq -r '.result.channels[].channel_id')\n\nIFS=$'\\n'\nchannel_array=($channel_ids)\nunset IFS\n\nfor channel_id in \"${channel_array[@]}\"; do\n  echo \"Shutting down channel: $channel_id\"",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1119",
+      "id": "chunk-1137",
       "title": "break-change-migrate",
       "content": "# Send shutdown request for each channel\n  curl -X POST http://127.0.0.1:8228 \\\n    -H \"Content-Type: application/json\" \\\n    -H \"Accept: application/json\" \\\n    -d \"{\\\"id\\\": \\\"42\\\", \\\"jsonrpc\\\": \\\"2.0\\\", \\\"method\\\": \\\"shutdown_channel\\\", \\\"params\\\": [{\\\"channel_id\\\": \\\"$channel_id\\\", \\\"close_script\\\": { \\\"code_hash\\\": \\\"$code_hash\\\", \\\"hash_type\\\": \\\"$hash_type\\\", \\\"args\\\": \\\"$script_args\\\" }, \\\"fee_rate\\\": \\\"0x3E8\\\", \\\"force\\\": false}] }\" | jq .\n\n  echo \"-------\"\ndone\n```\n\nWait for a while to make sure the shutdown transaction is submitted to the chain, and channel statuses are changed to `Closed`:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1120",
+      "id": "chunk-1138",
       "title": "break-change-migrate",
       "content": "```bash\ncurl -s -X POST http://127.0.0.1:8228 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Accept: application/json\" \\\n  -d '{\"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{ \"include_closed\": true }]}' | jq '.result.channels[].state'\n```\n\nThis will return:\n\n```json\n{\n  \"state_name\": \"CLOSED\",\n  \"state_flags\": \"COOPERATIVE\"\n}\n{\n  \"state_name\": \"CLOSED\",\n  \"state_flags\": \"COOPERATIVE\"\n}\n```\n\nIf all your channels are closed cooperatively, you’re good to go—no need for the forceful shutdown!\n\n### 3. Uncooperative Shutdown Channel\n\nIf some channel peers are offline, you might need to take the forceful route. Here’s a script to handle that (no `close_script` needed):",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1121",
+      "id": "chunk-1139",
       "title": "break-change-migrate",
       "content": "```bash\n#!/bin/bash\n# First, get all channel IDs as a string\nchannel_ids=$(curl -s -X POST http://127.0.0.1:8228 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Accept: application/json\" \\\n  -d '{\"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{}]}' \\\n  | jq -r '.result.channels[].channel_id')\n\nIFS=$'\\n'\nchannel_array=($channel_ids)\nunset IFS\n\nfor channel_id in \"${channel_array[@]}\"; do\n  echo \"Shutting down channel: $channel_id\"\n\n  # Send shutdown request for each channel\n  curl -X POST http://127.0.0.1:8228 \\\n    -H \"Content-Type: application/json\" \\\n    -H \"Accept: application/json\" \\\n    -d \"{\\\"id\\\": \\\"42\\\", \\\"jsonrpc\\\": \\\"2.0\\\", \\\"method\\\": \\\"shutdown_channel\\\", \\\"params\\\": [{\\\"channel_id\\\": \\\"$channel_id\\\", \\\"force\\\": true}] }\" | jq .\n\n  echo \"-------\"\ndone\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1122",
+      "id": "chunk-1140",
       "title": "break-change-migrate",
       "content": "Double-check that all channels are `Closed`:\n\n```bash\ncurl -s -X POST http://127.0.0.1:8228 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Accept: application/json\" \\\n  -d '{\"id\": \"42\", \"jsonrpc\": \"2.0\", \"method\": \"list_channels\", \"params\": [{ \"include_closed\": true }]}' | jq '.result.channels[].state'\n```\n\nThis will return:\n\n```json\n{\n  \"state_name\": \"CLOSED\",\n  \"state_flags\": \"UNCOOPERATIVE\"\n}\n{\n  \"state_name\": \"CLOSED\",\n  \"state_flags\": \"UNCOOPERATIVE\"\n}\n```\n\nAnd that’s it! You’ve nailed the migration and are ready to upgrade to the latest Fiber node.\n\n- [Download latest version of Fiber](https://github.com/nervosnetwork/fiber/releases)\n- [Start run a Fiber node with new database](https://docs.fiber.world/docs/quick-start/run-a-node)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/break-change-migrate.md",
       "source": "notes/break-change-migrate.md"
     },
     {
-      "id": "chunk-1123",
+      "id": "chunk-1141",
       "title": "fuzz-testing",
       "content": "# Fuzz Testing & Deterministic Testing Plan for Fiber Network Node\n\n## 1. Fuzz Testing with cargo-fuzz / libFuzzer\n\n### Setup\n\nCreate a `fuzz/` directory under `crates/fiber-lib/` with a dedicated `Cargo.toml`:\n\n```\ncrates/fiber-lib/fuzz/\n├── Cargo.toml\n├── fuzz_targets/\n│   ├── fuzz_fiber_message.rs\n│   ├── fuzz_gossip_message.rs\n│   ├── fuzz_invoice.rs\n│   ├── fuzz_onion_packet.rs\n│   ├── fuzz_store_deserialize.rs\n│   ├── fuzz_path_finding.rs\n│   └── fuzz_tlc_state_machine.rs\n└── corpus/\n    ├── fuzz_fiber_message/\n    ├── fuzz_invoice/\n    └── ...\n```\n\n`fuzz/Cargo.toml`:\n```toml\n[package]\nname = \"fnn-fuzz\"\nversion = \"0.0.0\"\npublish = false\nedition = \"2021\"\n\n[package.metadata]\ncargo-fuzz = true",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1124",
+      "id": "chunk-1142",
       "title": "fuzz-testing",
       "content": "[dependencies]\nlibfuzzer-sys = \"0.4\"\nfnn = { path = \"..\", features = [\"sample\"] }\narbitrary = { version = \"1\", features = [\"derive\"] }\n\n[[bin]]\nname = \"fuzz_fiber_message\"\npath = \"fuzz_targets/fuzz_fiber_message.rs\"\ndoc = false\n\n[[bin]]\nname = \"fuzz_gossip_message\"\npath = \"fuzz_targets/fuzz_gossip_message.rs\"\ndoc = false\n\n[[bin]]\nname = \"fuzz_invoice\"\npath = \"fuzz_targets/fuzz_invoice.rs\"\ndoc = false\n\n[[bin]]\nname = \"fuzz_onion_packet\"\npath = \"fuzz_targets/fuzz_onion_packet.rs\"\ndoc = false\n\n[[bin]]\nname = \"fuzz_store_deserialize\"\npath = \"fuzz_targets/fuzz_store_deserialize.rs\"\ndoc = false\n```\n\n### Fuzz Target Priority (3 Tiers)\n\n#### Tier 1 — Pure Function Deserialization (Highest Value, Easiest)\n\nThese are stateless, pure parsing functions. Crash = bug.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1125",
+      "id": "chunk-1143",
       "title": "fuzz-testing",
       "content": "| Target | Entry Point | Why |\n|--------|-------------|-----|\n| `fuzz_fiber_message` | `FiberMessage::from_molecule_slice(&data)` | P2P message parsing — untrusted network input |\n| `fuzz_gossip_message` | `GossipMessage::from_molecule_slice(&data)` | Gossip protocol parsing — untrusted network input |\n| `fuzz_invoice` | `CkbInvoice::from_str(s)` | bech32m invoice decoding — user-provided input |\n| `fuzz_onion_packet` | `PeeledOnionPacket::deserialize(...)` | Onion routing — untrusted forwarded data |\n| `fuzz_store_deserialize` | `bincode::deserialize::<T>(&data)` for each store type | Persistence layer — corrupted data resilience |\n\nExample — `fuzz_fiber_message.rs`:\n```rust\n#![no_main]\nuse libfuzzer_sys::fuzz_target;\nuse fnn::fiber::types::FiberMessage;",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1126",
+      "id": "chunk-1144",
       "title": "fuzz-testing",
       "content": "fuzz_target!(|data: &[u8]| {\n    let _ = FiberMessage::from_molecule_slice(data);\n});\n```\n\nExample — `fuzz_invoice.rs`:\n```rust\n#![no_main]\nuse libfuzzer_sys::fuzz_target;\nuse fnn::invoice::CkbInvoice;\nuse std::str;\n\nfuzz_target!(|data: &[u8]| {\n    if let Ok(s) = str::from_utf8(data) {\n        let _ = CkbInvoice::from_str(s);\n    }\n});\n```\n\n#### Tier 2 — Structured Fuzz with `arbitrary` (Medium Effort)\n\nUse the `Arbitrary` derive macro to generate structured inputs for more complex surfaces.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1127",
+      "id": "chunk-1145",
       "title": "fuzz-testing",
       "content": "| Target | Entry Point | Why |\n|--------|-------------|-----|\n| Path finding | `find_path(source, target, amount, ...)` | Complex graph algorithm with edge cases |\n| Serialization roundtrip | Encode → decode → assert equality | Catch asymmetries in molecule/bincode codecs |\n| Channel parameter validation | `OpenChannel` / `AcceptChannel` field ranges | Ensure parameter bounds are enforced |\n\nExample — roundtrip fuzz:\n```rust\n#![no_main]\nuse libfuzzer_sys::fuzz_target;\nuse arbitrary::Arbitrary;\nuse fnn::fiber::types::FiberMessage;",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1128",
+      "id": "chunk-1146",
       "title": "fuzz-testing",
       "content": "fuzz_target!(|data: &[u8]| {\n    // Parse message from fuzz data\n    if let Ok(msg) = FiberMessage::from_molecule_slice(data) {\n        // Re-serialize and re-parse\n        let bytes = msg.to_molecule_bytes();\n        let msg2 = FiberMessage::from_molecule_slice(&bytes)\n            .expect(\"roundtrip should succeed\");\n        // Could also assert structural equality if PartialEq is derived\n    }\n});\n```\n\n#### Tier 3 — Stateful Fuzz / Property-Based Testing (Highest Effort, Highest Impact)\n\nUse `proptest` or `arbitrary` to generate sequences of operations and test state machine invariants.\n\n**Best candidate**: The existing `TlcActor` in `tests/tlc_op.rs` is already a standalone state machine simulator that processes sequences of `Apply(TlcOp)` and `Sign` commands. This can be directly fuzzed.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1129",
+      "id": "chunk-1147",
       "title": "fuzz-testing",
       "content": "```rust\n// proptest strategy for TLC operation sequences\nuse proptest::prelude::*;\nuse proptest::collection::vec;\n\nfn tlc_op_strategy() -> impl Strategy<Value = TlcOp> {\n    prop_oneof![\n        (any::<u64>(), any::<[u8; 32]>()).prop_map(|(amount, hash)| {\n            TlcOp::AddTlc { amount, payment_hash: Hash256::from(hash) }\n        }),\n        any::<u64>().prop_map(|id| TlcOp::RemoveTlc { id }),\n    ]\n}\n\nfn command_strategy() -> impl Strategy<Value = TlcActorCommand> {\n    prop_oneof![\n        tlc_op_strategy().prop_map(TlcActorCommand::Apply),\n        Just(TlcActorCommand::Sign),\n        Just(TlcActorCommand::RevokeAndAck),\n    ]\n}",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1130",
+      "id": "chunk-1148",
       "title": "fuzz-testing",
       "content": "proptest! {\n    #[test]\n    fn test_tlc_state_machine_invariants(\n        commands in vec(command_strategy(), 1..100)\n    ) {\n        let mut actor = TlcActor::new();\n        for cmd in commands {\n            let _ = actor.handle(cmd); // should never panic\n        }\n        // Assert invariants:\n        // - committed TLC count >= 0\n        // - no duplicate TLC IDs\n        // - total value within bounds\n    }\n}\n```\n\n---\n\n## 2. Actor-Based State Machine Testing\n\n### Current Test Infrastructure\n\nThe codebase already has good testing infrastructure for actors:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1131",
+      "id": "chunk-1149",
       "title": "fuzz-testing",
       "content": "- **`MockChainActor`**: Simulates the CKB chain actor for channel tests\n- **`NetworkNode`**: Builder pattern for spinning up full node instances in tests\n- **`TlcActor`** (in `tests/tlc_op.rs`): Standalone TLC state machine that doesn't require ractor at all — **best target for deterministic testing**\n\n### Strategy: Extract Core Logic from Actors\n\nThe most practical approach for making actor logic testable:\n\n1. **Separate pure state transitions from actor message handling**:\n   ```rust\n   // Pure function — easy to test/fuzz\n   fn process_open_channel(\n       state: &mut ChannelState,\n       msg: &OpenChannel,\n   ) -> Result<AcceptChannel, Error> { ... }",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1132",
+      "id": "chunk-1150",
       "title": "fuzz-testing",
       "content": "// Actor handler — just delegates\n   async fn handle(&self, msg: ChannelActorMessage, state: &mut State) {\n       match msg {\n           ChannelActorMessage::PeerMessage(OpenChannel(m)) => {\n               match process_open_channel(&mut state.channel, &m) {\n                   Ok(response) => self.send(response),\n                   Err(e) => self.close_with_error(e),\n               }\n           }\n       }\n   }\n   ```\n\n2. **Create a `ChannelStateMachine` struct** similar to the existing `TlcActor`:\n   ```rust\n   struct ChannelStateMachine {\n       local_state: ChannelState,\n       remote_state: ChannelState,\n   }",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1133",
+      "id": "chunk-1151",
       "title": "fuzz-testing",
       "content": "impl ChannelStateMachine {\n       fn apply(&mut self, who: Role, msg: ChannelMessage) -> Result<Vec<ChannelMessage>, Error>;\n       fn check_invariants(&self) -> Result<(), String>;\n   }\n   ```\n\n3. **Fuzz the state machine** with `proptest` sequences of valid/invalid messages.\n\n---\n\n## 3. Deterministic Testing Strategies\n\n### Ractor Limitations\n\nRactor (the actor framework used by Fiber) has **no built-in support** for:\n- Deterministic scheduling\n- Virtual clocks\n- Simulation testing\n- Mock actors / test harnesses\n\nThis means deterministic testing must be achieved through other means.\n\n### Approach A: Message Record / Replay (Medium Effort)\n\nRecord all actor messages during a test run, then replay deterministically:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1134",
+      "id": "chunk-1152",
       "title": "fuzz-testing",
       "content": "```rust\n#[derive(Clone, Serialize, Deserialize)]\nstruct MessageLog {\n    entries: Vec<LogEntry>,\n}\n\nstruct LogEntry {\n    timestamp: u64,\n    from: ActorId,\n    to: ActorId,\n    message: SerializedMessage,\n}\n\n// Wrapper around actor that logs all messages\nstruct InstrumentedActor<A: Actor> {\n    inner: A,\n    log: Arc<Mutex<MessageLog>>,\n}\n```\n\n**Pros**: Works with existing ractor, captures real execution traces.\n**Cons**: Non-deterministic recording, replay may diverge if logic depends on timing.\n\n### Approach B: Extract Pure Functions (Recommended, Low Effort)\n\nFactor out all decision-making logic into pure functions that can be tested without actors:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1135",
+      "id": "chunk-1153",
       "title": "fuzz-testing",
       "content": "```rust\n// ❌ Logic buried in actor handler\nasync fn handle(&self, msg: NetworkMsg, state: &mut State) {\n    match msg {\n        NetworkMsg::PeerConnected(peer) => {\n            if state.peers.len() >= MAX_PEERS { return; }\n            state.peers.insert(peer.id, peer);\n            // ... complex logic\n        }\n    }\n}\n\n// ✅ Logic extracted into testable function\nfn handle_peer_connected(\n    peers: &mut HashMap<PeerId, PeerInfo>,\n    peer: PeerInfo,\n    max_peers: usize,\n) -> Result<Vec<SideEffect>, Error> {\n    if peers.len() >= max_peers {\n        return Err(Error::TooManyPeers);\n    }\n    peers.insert(peer.id, peer.clone());\n    Ok(vec![SideEffect::SendHandshake(peer.id)])\n}",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1136",
+      "id": "chunk-1154",
       "title": "fuzz-testing",
       "content": "#[cfg(test)]\nmod tests {\n    #[test]\n    fn test_peer_connected_max_limit() {\n        let mut peers = HashMap::new();\n        // Fill to max\n        for i in 0..MAX_PEERS {\n            let peer = make_peer(i);\n            handle_peer_connected(&mut peers, peer, MAX_PEERS).unwrap();\n        }\n        // Next should fail\n        let result = handle_peer_connected(&mut peers, make_peer(999), MAX_PEERS);\n        assert!(result.is_err());\n    }\n}\n```\n\n**Pros**: Fully deterministic, fast, easy to fuzz with proptest.\n**Cons**: Requires refactoring actor handlers (can be done incrementally).\n\n### Approach C: Turmoil for Network Simulation (High Effort, Future)\n\n[Turmoil](https://github.com/tokio-rs/turmoil) (by tokio-rs) provides deterministic single-threaded simulation of networked systems:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1137",
+      "id": "chunk-1155",
       "title": "fuzz-testing",
       "content": "```rust\nuse turmoil::Builder;\n\n#[test]\nfn test_channel_open_under_partition() {\n    let mut sim = Builder::new()\n        .simulation_duration(Duration::from_secs(60))\n        .build();\n\n    sim.host(\"alice\", || async {\n        let node = start_fiber_node(config_alice()).await;\n        node.open_channel(\"bob\", 1000).await?;\n        Ok(())\n    });\n\n    sim.host(\"bob\", || async {\n        let node = start_fiber_node(config_bob()).await;\n        // Accept channel\n        Ok(())\n    });\n\n    // Partition network after channel open\n    sim.partition(\"alice\", \"bob\");\n    sim.run().unwrap();\n}\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1138",
+      "id": "chunk-1156",
       "title": "fuzz-testing",
       "content": "**Pros**: True deterministic simulation, network fault injection, reproducible failures.\n**Cons**: Requires replacing real TCP with turmoil's simulated TCP. Ractor uses internal tokio channels — significant integration work needed.\n\n### Framework Comparison\n\n| Framework | Deterministic | Network Sim | Ractor Compatible | Effort |\n|-----------|:---:|:---:|:---:|:---:|\n| **proptest** (state machine) | ✅ | ❌ | ✅ (no actors needed) | Low |\n| **cargo-fuzz** (libfuzzer) | ❌ | ❌ | ✅ (no actors needed) | Low |\n| **turmoil** (tokio-rs) | ✅ | ✅ | ⚠️ (high integration) | High |\n| **madsim** (madeng) | ✅ | ✅ | ❌ (replaces tokio) | Very High |\n| **Message replay** | Partial | ❌ | ✅ | Medium |\n\n---\n\n## 4. Recommended Implementation Order",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1139",
+      "id": "chunk-1157",
       "title": "fuzz-testing",
       "content": "### Phase 1 — Quick Wins (1-2 days)\n1. Set up `crates/fiber-lib/fuzz/` with cargo-fuzz\n2. Implement Tier 1 fuzz targets:\n   - `fuzz_fiber_message` (P2P message parsing)\n   - `fuzz_gossip_message` (gossip parsing)\n   - `fuzz_invoice` (invoice decoding)\n   - `fuzz_onion_packet` (onion routing)\n3. Seed corpus from existing test fixtures and serialized protocol messages\n4. Run locally for a few hours, fix any crashes\n\n### Phase 2 — Property-Based Testing (3-5 days)\n1. Add `proptest` as a dev-dependency\n2. Fuzz the `TlcActor` state machine (already standalone, perfect candidate)\n3. Add serialization roundtrip property tests for all molecule types\n4. Add `arbitrary` derives to key types behind a feature flag",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1140",
+      "id": "chunk-1158",
       "title": "fuzz-testing",
       "content": "### Phase 3 — Actor Logic Extraction (Ongoing)\n1. Identify the most complex actor handlers (channel state transitions, payment forwarding)\n2. Extract core logic into pure functions (`fn handle_X(state, input) -> Result<(new_state, effects)>`)\n3. Add property-based tests for the extracted functions\n4. Use `proptest` state machine testing to verify sequences of operations\n\n### Phase 4 — CI Integration\n1. Add a nightly CI job that runs fuzz targets for N minutes each\n2. Archive corpus in the repo (committed to `fuzz/corpus/`)\n3. Track coverage with `cargo-fuzz coverage` and report regressions\n4. Add `proptest` tests to the regular CI test suite\n\n```yaml\n# .github/workflows/fuzz.yml\nname: Fuzz Testing\non:\n  schedule:\n    - cron: '0 2 * * *'  # Nightly at 2am\n  workflow_dispatch:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1141",
+      "id": "chunk-1159",
       "title": "fuzz-testing",
       "content": "jobs:\n  fuzz:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        target:\n          - fuzz_fiber_message\n          - fuzz_gossip_message\n          - fuzz_invoice\n          - fuzz_onion_packet\n    steps:\n      - uses: actions/checkout@v4\n      - uses: dtolnay/rust-toolchain@nightly\n      - run: cargo install cargo-fuzz\n      - run: |\n          cd crates/fiber-lib\n          cargo fuzz run ${{ matrix.target }} -- -max_total_time=600\n      - uses: actions/upload-artifact@v4\n        if: failure()\n        with:\n          name: fuzz-artifacts-${{ matrix.target }}\n          path: crates/fiber-lib/fuzz/artifacts/\n```\n\n---\n\n## 5. Key Considerations",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1142",
+      "id": "chunk-1160",
       "title": "fuzz-testing",
       "content": "### WASM Compatibility\n- Fuzz targets only need to build for native (x86_64), not WASM\n- The `fuzz/` directory is a separate crate, won't affect WASM builds\n- If extracting logic for testing, ensure extracted functions remain WASM-compatible\n\n### Existing Test Pattern: TlcActor\nThe `TlcActor` in `tests/tlc_op.rs` is the gold standard in this codebase for deterministic state machine testing. It:\n- Runs without ractor (pure state machine)\n- Simulates both sides of a channel\n- Processes sequences of `Apply(TlcOp)` and `Sign` commands\n- Validates invariants after each step\n\n**This pattern should be replicated for other subsystems** (channel state machine, payment forwarding, gossip protocol).",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1143",
+      "id": "chunk-1161",
       "title": "fuzz-testing",
       "content": "### Store/Persistence Fuzzing\nWith the `StoreSample` trait already implemented for all store types, creating corpus seeds is straightforward:\n```rust\nlet sample = ChannelActorState::sample();\nlet bytes = bincode::serialize(&sample).unwrap();\nstd::fs::write(\"fuzz/corpus/fuzz_store_deserialize/seed_channel_state\", bytes).unwrap();\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/fuzz-testing.md",
       "source": "notes/fuzz-testing.md"
     },
     {
-      "id": "chunk-1144",
+      "id": "chunk-1162",
       "title": "gossip",
       "content": "# Gossip in Fiber: Architecture, Data Flow, and Operational Notes\n\nThis note documents the **Fiber** gossip subsystem from an engineering perspective.\n\n## 1. What Gossip Solves\n\nFiber nodes need a shared(ish) view of the network to do routing and validation:\n\n- **Node information** (identity, addresses, feature bits).\n- **Public channels** (existence of an edge between two nodes).\n- **Channel state updates** (fee policy, HTLC constraints, enabled/disabled, direction).\n\nIn a decentralized network:\n\n- Each node connects to only a small subset of peers.\n- Peers can disconnect, partitions happen, nodes restart.\n- Peers can be malicious (spam, eclipse-style isolation).\n\nSo gossip must provide:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1145",
+      "id": "chunk-1163",
       "title": "gossip",
       "content": "- **Catch-up (history sync)** after downtime or partitions.\n- **Incremental updates (subscription)** once caught up.\n- **Verification and dependency handling** so “received” does not automatically mean “accepted/applied”.\n- **Resource bounds** (rate limiting, peer targeting) for safety and scalability.\n\n---\n\n## 2. Key Concepts in Fiber\n\n### 2.1 Broadcast messages and the Cursor\n\nFiber treats gossip as an **ordered stream** of broadcast messages.\n\n- Messages are stored with a monotonic ordering key called a **Cursor**.\n- Conceptually: `Cursor = (timestamp, message_id)`.\n\nThis enables a clean primitive:\n\n- “Give me messages **after** cursor X, up to N items.”\n\nThis is implemented by the `GossipMessageStore` trait in `gossip.rs`, backed by the DB store.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1146",
+      "id": "chunk-1164",
       "title": "gossip",
       "content": "### 2.2 Two sync modes: active vs passive\n\nFiber tracks per-peer sync state via `PeerSyncStatus` (in `gossip.rs`).\n\n- **Active syncing (pull history)**\n\t- State: `ActiveGet(...)`\n\t- Mechanism: repeatedly send `GetBroadcastMessages(after_cursor, count)` and advance the cursor.\n\t- Completion: when the peer returns an empty batch, the peer is considered “caught up”.\n\n- **Passive syncing (subscribe/push updates)**\n\t- State: `PassiveFilter(cursor)`\n\t- Mechanism: send `BroadcastMessagesFilter(after_cursor)` so the peer pushes updates.\n\t- Goal: reduce silos and keep the node up-to-date without constant pulling.\n\nThese are not competing modes; they are typically used in phases:\n\n1) Active sync with a limited number of peers to catch up.\n2) Passive subscriptions to keep up continuously.\n\n---",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1147",
+      "id": "chunk-1165",
       "title": "gossip",
       "content": "## 3. Architecture: Main Components\n\n### 3.1 Actors and responsibilities\n\nFiber splits the gossip subsystem into a few cooperating actors:\n\n- `GossipActor` (control plane)\n\t- Tracks connected peers and their `PeerSyncStatus`.\n\t- Decides which peers to actively sync vs passively subscribe.\n\t- Routes incoming protocol messages to the right internal component.\n\t- Triggers periodic maintenance (network tick, pruning stale messages).\n\n- `GossipSyncingActor` (data plane for active syncing)\n\t- Dedicated per-peer worker for **pulling history**.\n\t- Sends `GetBroadcastMessages` and processes `GetBroadcastMessagesResult`.\n\t- On completion, notifies `GossipActor`.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1148",
+      "id": "chunk-1166",
       "title": "gossip",
       "content": "- `PeerFilterProcessor` (subscription management)\n\t- Manages subscription filters for peers.\n\t- Updates the store subscription cursor when a peer changes `after_cursor`.\n\n- `ExtendedGossipMessageStore` (store actor + fan-out)\n\t- Receives batches of messages from `GossipActor` and saves them.\n\t- Performs dependency/ordering handling (important for correctness).\n\t- Fans out `GossipMessageUpdates` to subscribers.\n\n### 3.2 Where NetworkGraph fits\n\n`NetworkActor` subscribes to gossip store updates and applies them into `NetworkGraph`.\nThis is the primary pipeline that turns “gossip messages” into “routing graph state”.\n\n---\n\n## 4. Relationship Diagram (Network + Gossip + Store)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1149",
+      "id": "chunk-1167",
       "title": "gossip",
       "content": "```mermaid\nflowchart LR\n\tsubgraph P2P[P2P Service]\n\t\tSess[Session / Peer]\n\t\tGossipProto[GossipProtocolHandle]\n\t\tFiberProto[FiberProtocolHandle]\n\tend\n\n\tsubgraph Net[fiber/network.rs]\n\t\tNA[NetworkActor]\n\tend\n\n\tsubgraph Gossip[fiber/gossip.rs]\n\t\tGA[GossipActor]\n\t\tGSA[GossipSyncingActor]\n\t\tPFP[PeerFilterProcessor]\n\t\tES[ExtendedGossipMessageStore Actor]\n\tend\n\n\tsubgraph Store[store/store_impl]\n\t\tDB[Store DB]\n\tend\n\n\tsubgraph Graph[fiber/graph.rs]\n\t\tNG[NetworkGraph]\n\tend\n\n\tsubgraph Chain[ckb]\n\t\tCA[CkbChainActor]\n\tend\n\n\tSess --> GossipProto\n\tSess --> FiberProto\n\n\tGossipProto -->|PeerConnected| GA\n\tGossipProto -->|GossipMessageReceived| GA\n\n\tNA -->|BroadcastMessages| GA\n\tGA -->|SaveAndBroadcastMessages| ES\n\tGA -->|SaveMessages| ES",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1150",
+      "id": "chunk-1168",
       "title": "gossip",
       "content": "GA -->|start active sync| GSA\n\tGSA -->|GetBroadcastMessages| GossipProto\n\tGossipProto -->|GetBroadcastMessagesResult| GA\n\tGA -->|ResponseReceived| GSA\n\tGSA -->|SaveMessages| ES\n\tGSA -->|ActiveSyncingFinished| GA\n\n\tGA -->|BroadcastMessagesFilter| GossipProto\n\tGossipProto -->|BroadcastMessagesFilter| GA\n\tGA -->|spawn/update| PFP\n\tPFP -->|UpdateSubscription| ES\n\tES -->|BroadcastMessagesFilterResult| GossipProto\n\tGossipProto -->|BroadcastMessagesFilterResult| GA\n\n\tES -->|persist/read| DB\n\n\tNA -->|subscribe store updates| ES\n\tES -->|GossipMessageUpdates| NA\n\tNA -->|apply updates| NG\n\n\tGA -->|verify deps| CA\n\tGSA -->|verify deps| CA\n```\n\n---\n\n## 5. Primary Data Flows\n\n### 5.1 Local broadcast (originating messages)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1151",
+      "id": "chunk-1169",
       "title": "gossip",
       "content": "When Fiber produces a local broadcast message (e.g., node announcement or public channel messages),\n`NetworkActor` sends it into gossip via `GossipActorMessage::TryBroadcastMessages(...)`.\n\n`GossipActor` passes these to `ExtendedGossipMessageStore` (save + fan-out) and to peers.\n\n### 5.2 Active syncing (pull history)\n\nActive syncing is driven by `GossipSyncingActor`:\n\n1) Start with a cursor.\n2) Send `GetBroadcastMessages(after_cursor)`.\n3) Receive `GetBroadcastMessagesResult(messages)`.\n4) Save messages into store, advance cursor.\n5) Repeat until empty result.\n\n### 5.3 Passive syncing (subscribe/push)\n\nPassive syncing is filter-based:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1152",
+      "id": "chunk-1170",
       "title": "gossip",
       "content": "1) Send `BroadcastMessagesFilter(after_cursor)` to a peer.\n2) The peer responds over time with `BroadcastMessagesFilterResult(messages)`.\n3) Save messages into store.\n\nThis is how a node stays updated after catching up.\n\n---\n\n## 6. Notes and Pitfalls\n\n### 6.1 “Received” does not mean “Applied”\n\nThe observable pipeline is:\n\n1) Protocol receives a gossip message.\n2) `GossipActor` routes it.\n3) Store verifies / checks dependencies / persists.\n4) Subscribers receive `GossipMessageUpdates`.\n5) `NetworkGraph` applies updates.\n\nIf any step drops or delays a message, you can see logs like “received X” without seeing the graph change.\n\n### 6.2 Immutable vs mutable messages",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1153",
+      "id": "chunk-1171",
       "title": "gossip",
       "content": "Some messages are effectively immutable and may be broadcast only once (e.g., channel announcements).\nIf your sync strategy starts from a cursor that is too new, you can miss these older-but-still-relevant\nmessages permanently.\n\nBy contrast, node announcements or channel updates tend to refresh over time, so missing one update is\noften healed by later updates.\n\n### 6.3 Cursor selection and “safe” cursors\n\nFiber uses the concept of a “safe cursor” to avoid syncing from genesis forever. This is practical,\nbut it must be chosen carefully:\n\n- Too old → bandwidth waste.\n- Too new → can miss important older messages.\n\nThis trade-off becomes visible when bridging two previously disconnected clusters.\n\n### 6.4 Dependency and ordering\n\nChannel-related updates can depend on:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1154",
+      "id": "chunk-1172",
       "title": "gossip",
       "content": "- Having a channel announcement present.\n- Having chain/onchain info available.\n- Satisfying timestamp and signature constraints.\n\nA robust store layer typically needs to handle out-of-order arrival and cache/resolve dependencies.\n\n### 6.5 Eclipse-resistance considerations\n\nFiber distinguishes targeted **outbound** passive syncing peers to reduce eclipse risk. Practical\nnotes:\n\n- Prefer maintaining subscriptions with multiple independent outbound peers.\n- Limit concurrent active syncing peers to bound bandwidth and CPU.\n\n---\n\n## 7. References (code)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1155",
+      "id": "chunk-1173",
       "title": "gossip",
       "content": "- Gossip protocol + actors: `crates/fiber-lib/src/fiber/gossip.rs`\n- Network startup + subscription wiring: `crates/fiber-lib/src/fiber/network.rs`\n- Persistent storage for broadcast messages: `crates/fiber-lib/src/store/store_impl/mod.rs`\n- Graph application of gossip updates: `crates/fiber-lib/src/fiber/graph.rs`",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/gossip.md",
       "source": "notes/gossip.md"
     },
     {
-      "id": "chunk-1156",
+      "id": "chunk-1174",
       "title": "state-updates-across-multiple-actors",
       "content": "# State updates across multiple actors\n\nOne of the major problems of actor model is that updating multiple actors as a single atomic operation is a challenging task. For example, sometimes we want to update the channel actor and network actor atomically. Normally, it should not be a big problem even if there is a short period when the states shared between different actors are inconsistent, but we should be especially careful while updating these states.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/state-updates-across-multiple-actors.md",
       "source": "notes/state-updates-across-multiple-actors.md"
     },
     {
-      "id": "chunk-1157",
+      "id": "chunk-1175",
       "title": "v0.8.0-migration-guide",
       "content": "# v0.8.0 Migration Guide\n\nThis guide covers upgrading a Fiber node from v0.7.x to v0.8.0.\n\nUnlike the v0.7.0 migration (which required closing all channels and starting\nfresh), **v0.8.0 supports in-place data migration**. The `fnn-migrate` tool\nwill update your existing database without losing channel state or funds.\n\n## Prerequisites\n\n- Fiber node is running v0.7.0 or v0.7.1\n- Node is **stopped** (not running)\n- A recent backup of your data directory (see the [backup guide](backup-guide.md))\n\n## Step 1: Stop the node\n\n```bash\n# Find the running process\nps aux | grep fnn\n\n# Terminate it (replace PID with your process ID)\nkill <PID>\n```\n\n## Step 2: Back up your data directory\n\nAlways create a backup before migrating:\n\n```bash\ntar -zcvf backup-fiber-dir.tar.gz fiber-dir\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/v0.8.0-migration-guide.md",
       "source": "notes/v0.8.0-migration-guide.md"
     },
     {
-      "id": "chunk-1158",
+      "id": "chunk-1176",
       "title": "v0.8.0-migration-guide",
       "content": "## Step 3: Build or download v0.8.0\n\nBuild from source:\n\n```bash\ngit checkout v0.8.0\ncargo build --release -p fnn\ncargo build --release --manifest-path migrate/Cargo.toml\n```\n\nOr download the pre-built binaries from the\n[releases page](https://github.com/nervosnetwork/fiber/releases).\n\n## Step 4: Run the migration tool\n\n```bash\n./fnn-migrate -d /path/to/fiber-dir\n```\n\nThe `-d` / `--dir` flag takes the Fiber data directory (same as `fnn -d`).\nThe tool opens the RocksDB store at `<dir>/store` automatically.\n\nThe tool applies all pending migrations in order. You will see log output for\neach migration step:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/v0.8.0-migration-guide.md",
       "source": "notes/v0.8.0-migration-guide.md"
     },
     {
-      "id": "chunk-1159",
+      "id": "chunk-1177",
       "title": "v0.8.0-migration-guide",
       "content": "| Migration | What it does |\n|-----------|-------------|\n| Channel actor state (prefix 0) | Appends new `pending_replay_updates` and `last_was_revoke` fields with default values |\n| Channel-by-pubkey index (prefix 64) | Re-keys the channel index from PeerId to Pubkey |\n| Network actor state (prefix 16) | Clears legacy PeerId-keyed network state (rebuilt on next start) |\n| Channel open records (prefix 201) | Deletes ephemeral channel-opening status records (rebuilt if needed) |\n\nThe migration is idempotent — running it again on an already-migrated database\nis safe and will be a no-op.\n\n## Step 5: Update your configuration\n\nNo configuration file changes are required for v0.8.0.\n\n## Step 6: Start the node\n\n```bash\n./fnn -c /path/to/fiber-dir/config.yml -d /path/to/fiber-dir\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/v0.8.0-migration-guide.md",
       "source": "notes/v0.8.0-migration-guide.md"
     },
     {
-      "id": "chunk-1160",
+      "id": "chunk-1178",
       "title": "v0.8.0-migration-guide",
       "content": "On first start after migration the node will:\n\n- Rebuild the network peer address map from gossip\n- Re-establish connections with known peers\n- Resume any in-flight payments\n\n## RPC client changes\n\nv0.8.0 introduces several RPC breaking changes. If you have scripts or\nintegrations that call the Fiber RPC, update them for the following:\n\n### PeerId → Pubkey\n\nAll `peer_id` parameters and response fields have been replaced with `pubkey`.\nPeerIds were base58-encoded libp2p identifiers; Pubkeys are hex-encoded\ncompressed secp256k1 public keys (66 hex characters).\n\n**Before (v0.7.x):**\n```json\n{\"method\": \"open_channel\", \"params\": [{\"peer_id\": \"QmXxx...\"}]}\n```\n\n**After (v0.8.0):**\n```json\n{\"method\": \"open_channel\", \"params\": [{\"pubkey\": \"02abc...\"}]}\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/v0.8.0-migration-guide.md",
       "source": "notes/v0.8.0-migration-guide.md"
     },
     {
-      "id": "chunk-1161",
+      "id": "chunk-1179",
       "title": "v0.8.0-migration-guide",
       "content": "Affected RPCs: `open_channel`, `list_channels`, `connect_peer`,\n`disconnect_peer`, `node_info`.\n\n### JSON serialization changes\n\n- `Attribute` enum variants are now snake_case: `FinalHtlcTimeout` → `final_htlc_timeout`\n- `HashAlgorithm` variants are now snake_case: `CkbHash` → `ckb_hash`\n- `CkbInvoice.signature` is now a hex string instead of a structured object\n- `ChannelState` flags format: `\"OUR_INIT_SENT | THEIR_INIT_SENT\"` (SCREAMING_SNAKE_CASE with pipes)\n- CCH invoice variants now carry encoded invoice strings instead of structured objects\n\n### CCH order status renames\n\n- `Succeeded` → `Success`\n- `OutgoingSucceeded` → `OutgoingSuccess`\n\n### Error behavior\n\n`connect_peer` and `disconnect_peer` now return proper RPC errors on failure\ninstead of silently returning success.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/v0.8.0-migration-guide.md",
       "source": "notes/v0.8.0-migration-guide.md"
     },
     {
-      "id": "chunk-1162",
+      "id": "chunk-1180",
       "title": "v0.8.0-migration-guide",
       "content": "## Troubleshooting\n\n### Migration fails with \"unexpected end of file\"\n\nThis usually means the database was written by a version newer than v0.7.x.\nVerify you're migrating from v0.7.0 or v0.7.1.\n\n### Node fails to start after migration\n\n1. Check the error message in the logs\n2. Restore from backup: `tar -xzf backup-fiber-dir.tar.gz`\n3. Re-run the migration tool\n4. If the problem persists, open an issue at\n   https://github.com/nervosnetwork/fiber/issues\n\n### Channels show as disconnected after upgrade\n\nThis is expected. The node will automatically reconnect to peers and\nre-establish channels. Allow a few minutes for the network to stabilize.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/notes/v0.8.0-migration-guide.md",
       "source": "notes/v0.8.0-migration-guide.md"
     },
     {
-      "id": "chunk-1163",
+      "id": "chunk-1181",
       "title": "payment-lifecycle",
       "content": "# Fiber Payment Lifecycle\n\nThis document provides a comprehensive visualization of the `PaymentSession` and `PaymentAttempt` lifecycles in the Fiber network.\n\n## State Machine Overview\n\nThe following diagram illustrates the decoupled, event-driven transitions between the high-level payment intent (Session) and the individual routing attempts.\n\n```mermaid\n    flowchart TB\n    subgraph PaymentSession [Payment Session]\n        direction TB\n        PS_Created[Created] --> PS_Inflight[Inflight]\n        PS_Inflight -- \"Σ(Settled Amount) == Total\" --> PS_Success[Success / Finished]\n        PS_Inflight -- \"Exhausted / Terminal Error\" --> PS_Failed[Failed]\n        \n        style PS_Success fill:#e1f5fe,stroke:#01579b\n        style PS_Failed fill:#ffebee,stroke:#b71c1c\n    end",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/payment-lifecycle.md",
       "source": "payment-lifecycle.md"
     },
     {
-      "id": "chunk-1164",
+      "id": "chunk-1182",
       "title": "payment-lifecycle",
       "content": "subgraph Attempts [Payment Attempts]\n        direction TB\n        A_Created[Attempt 1..N] --> A_Inflight[Inflight]\n        A_Inflight --> A_Result{Result?}\n        A_Result -- \"Fulfill\" --> A_Settled[Settled]\n        A_Result -- \"Fail (Retryable)\" --> A_Retrying[Retrying]\n        A_Result -- \"Fail (Final)\" --> A_Failed[Failed]\n        \n        A_Retrying --> A_Inflight\n    end\n\n    %% Aggregation & MPP Logic\n    PS_Created -- \"Splits Amount\" --> A_Created\n    A_Settled -- \"Partial Amount Collected\" --> PS_Inflight\n    A_Settled -- \"Full Amount Reached\" --> PS_Success\n    A_Failed -- \"Cannot fulfill Total Amount\" --> PS_Failed",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/payment-lifecycle.md",
       "source": "payment-lifecycle.md"
     },
     {
-      "id": "chunk-1165",
+      "id": "chunk-1183",
       "title": "public-nodes",
       "content": "# Public Nodes User Manual\n\n> **Version note:** This document is for fnn `v0.8.0` and later. It is **not** compatible with earlier versions (e.g. `v0.7.1`), because [PR #1154](https://github.com/nervosnetwork/fiber/pull/1154) replaced `PeerId` with `Pubkey` across all RPC interfaces — the `peer_id` parameter in `connect_peer`, `open_channel`, `list_channels`, etc. was renamed to `pubkey`. For earlier versions, please see [docs/testnet-nodes.md@v0.7.1](https://github.com/nervosnetwork/fiber/blob/v0.7.1/docs/testnet-nodes.md).\n\n## Public Nodes\n\n### Mainnet\n\n#### node1\n\n- pubkey: `03a8d7da8d0934363dbc17f52c872e8d833016415266eabb3527439c5dd17adc6b`\n\n#### node2\n\n- pubkey: `033a69e5be369dab43aefa96fa729d83c571ccb066f312136c6ab2d354fcc028f9`\n\n### Testnet\n\n#### node1",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1166",
+      "id": "chunk-1184",
       "title": "public-nodes",
       "content": "- pubkey: `02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71`\n\n#### node2\n\n- pubkey: `0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc`\n\n## Overview\n\nIn this guide, we will deploy two local nodes (nodeA and nodeB) and connect them to the public relay nodes (node1 and node2) to perform multi-hop payments. The overall topology is:\n\n```\n┌───────┐        ┌───────┐        ┌───────┐        ┌───────┐\n│ nodeA │ ─────▶ │ node1 │ ─────▶ │ node2 │ ─────▶ │ nodeB │\n│:8227  │        │public │        │public │        │:8237  │\n└───────┘        └───────┘        └───────┘        └───────┘\n  sender        relay node 1     relay node 2      receiver\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1167",
+      "id": "chunk-1185",
       "title": "public-nodes",
       "content": "In this demo, nodeA and nodeB run on the same machine for convenience. In a real-world scenario, they would be on separate machines, each connecting only to a public relay node. The benefit is that local nodes do not need to expose a publicly reachable address — they can send and receive payments through the public relay nodes.\n\n## Channel Capacity",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1168",
+      "id": "chunk-1186",
       "title": "public-nodes",
       "content": "When opening a channel, each side must reserve 99 CKB (98 CKB for [commitment lock occupied capacity](https://github.com/nervosnetwork/fiber/blob/2ab20ffb50243c25109a62ef2ac18b7e4f1a9e70/crates/fiber-lib/src/fiber/config.rs#L23) + 1 CKB for [shutdown transaction fee](https://github.com/nervosnetwork/fiber/blob/2ab20ffb50243c25109a62ef2ac18b7e4f1a9e70/crates/fiber-lib/src/fiber/config.rs#L18)) to ensure sufficient funds for on-chain settlement when the channel closes. This reserved amount is not available for off-chain payments.\n\nFor example, if nodeA funds 499 CKB and the public node contributes 250 CKB:\n\n- nodeA available: 499 - 99 = 400 CKB\n- public node available: 250 - 99 = 151 CKB\n\n## Local Node Deployment\n\n1. Download fnn",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1169",
+      "id": "chunk-1187",
       "title": "public-nodes",
       "content": "Please visit the [releases page](https://github.com/nervosnetwork/fiber/releases) to download and use the latest version of fnn.\n\n   ```bash\n   mkdir tmp && cd tmp\n   tar xzvf fnn-latest.tar.gz\n   ```\n\n2. Export the account private key to the fiber node's ckb directory\n\n   Here, ckb-cli is used to create accounts, which will later be used to fund channel openings between local nodes and public nodes. If ckb-cli is not installed, please download it from the [releases](https://github.com/nervosnetwork/ckb-cli/releases).\n\n   First, set your working directory based on the target network:\n\n   ```bash\n   # For mainnet:\n   FNNDIR=mainnet-fnn\n   # For testnet (uncomment and comment out the line above):\n   # FNNDIR=testnet-fnn\n   ```\n\n   Then create directories and export keys:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1170",
+      "id": "chunk-1188",
       "title": "public-nodes",
       "content": "```bash\n   # Create local node directories\n   mkdir -p $FNNDIR/nodeA/ckb $FNNDIR/nodeB/ckb\n\n   # Create accounts for nodeA and nodeB (replace <lock_arg_a/b> with the lock_arg from each output)\n   ./ckb-cli account new  # -> nodeA account\n   ./ckb-cli account export --lock-arg <lock_arg_a> --extended-privkey-path exported-key-a\n   head -n 1 ./exported-key-a > $FNNDIR/nodeA/ckb/key && chmod 600 $FNNDIR/nodeA/ckb/key\n\n   ./ckb-cli account new  # -> nodeB account\n   ./ckb-cli account export --lock-arg <lock_arg_b> --extended-privkey-path exported-key-b\n   head -n 1 ./exported-key-b > $FNNDIR/nodeB/ckb/key && chmod 600 $FNNDIR/nodeB/ckb/key\n\n   # Verify keys\n   ./ckb-cli util key-info --privkey-path $FNNDIR/nodeA/ckb/key\n   ./ckb-cli util key-info --privkey-path $FNNDIR/nodeB/ckb/key\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1171",
+      "id": "chunk-1189",
       "title": "public-nodes",
       "content": "3. Copy and configure config.yml\n\n   **Mainnet**\n\n   ```bash\n   cp config/mainnet/config.yml $FNNDIR/nodeA\n   cp config/mainnet/config.yml $FNNDIR/nodeB\n   ```\n\n   As the comment says, \"[use a trusted CKB RPC node](https://github.com/nervosnetwork/fiber/blob/2ab20ffb50243c25109a62ef2ac18b7e4f1a9e70/config/mainnet/config.yml#L55)\" should be changed to the RPC endpoint of a CKB node you trust. For convenience, I used [Public JSON RPC nodes](https://github.com/nervosnetwork/ckb/wiki/Public-JSON-RPC-nodes) here.\n\n   ```bash\n   sed -i.bak 's|rpc_url:.*|rpc_url: \"https://mainnet.ckbapp.dev/\"|' $FNNDIR/nodeA/config.yml\n   grep rpc_url $FNNDIR/nodeA/config.yml\n   ```\n\n   For nodeB, also modify `rpc_url` and change the listening ports to avoid conflicts with nodeA:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1172",
+      "id": "chunk-1190",
       "title": "public-nodes",
       "content": "```bash\n   sed -i.bak 's|rpc_url:.*|rpc_url: \"https://mainnet.ckbapp.dev/\"|' $FNNDIR/nodeB/config.yml\n   sed -i.bak 's|/ip4/0.0.0.0/tcp/8228|/ip4/0.0.0.0/tcp/8238|' $FNNDIR/nodeB/config.yml\n   sed -i.bak 's|127.0.0.1:8227|127.0.0.1:8237|' $FNNDIR/nodeB/config.yml\n   grep -wE 'rpc_url|listening_addr' $FNNDIR/nodeB/config.yml\n   ```\n\n   **Testnet**\n\n   ```bash\n   cp config/testnet/config.yml $FNNDIR/nodeA\n   cp config/testnet/config.yml $FNNDIR/nodeB\n   ```\n\n   The testnet config already has `rpc_url` set to `https://testnet.ckbapp.dev/`, so only nodeB's listening ports need to be changed:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1173",
+      "id": "chunk-1191",
       "title": "public-nodes",
       "content": "```bash\n   sed -i.bak 's|/ip4/0.0.0.0/tcp/8228|/ip4/0.0.0.0/tcp/8238|' $FNNDIR/nodeB/config.yml\n   sed -i.bak 's|127.0.0.1:8227|127.0.0.1:8237|' $FNNDIR/nodeB/config.yml\n   grep -wE 'rpc_url|listening_addr' $FNNDIR/nodeB/config.yml\n   ```\n\n4. Fund the accounts\n\n   **Mainnet**\n\n   Transfer CKB to both nodeA's and nodeB's addresses. Each node needs enough CKB to open a channel. The funding amount is 499 CKB, but additional CKB is required for the change cell (a standard secp256k1-blake160 cell occupies a minimum of 61 CKB) and the on-chain funding transaction fee. We recommend transferring at least 561 CKB per node (499 + 61 + 1 fee).\n\n   **Testnet**\n\n   Use the faucets to fund both nodeA's and nodeB's addresses:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1174",
+      "id": "chunk-1192",
       "title": "public-nodes",
       "content": "- CKB: https://faucet.nervos.org\n    - RUSD (for UDT channels): https://testnet0815.stablepp.xyz/faucet\n\n   The RUSD faucet cannot directly fill an address, so you can first claim RUSD through a wallet like [JoyID](https://testnet.joyid.dev/), then transfer it to your node's address.\n\n5. Start the nodes\n\n   You need to set the `FIBER_SECRET_KEY_PASSWORD` environment variable in the startup command. This is a user-chosen password used to encrypt and decrypt your CKB private key file — you can set it to any value you like. Please use a strong password and remember it, as you will need it every time you start the node.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1175",
+      "id": "chunk-1193",
       "title": "public-nodes",
       "content": "```bash\n   FIBER_SECRET_KEY_PASSWORD='your_password' RUST_LOG=info ./fnn -c $FNNDIR/nodeA/config.yml -d $FNNDIR/nodeA > $FNNDIR/nodeA/a.log 2>&1 &\n   FIBER_SECRET_KEY_PASSWORD='your_password' RUST_LOG=info ./fnn -c $FNNDIR/nodeB/config.yml -d $FNNDIR/nodeB > $FNNDIR/nodeB/b.log 2>&1 &\n   ```\n\n---\n\n## CKB Multi-Hop Payment\n\nThe CKB payment flow is identical on both mainnet and testnet. The only differences are the public node pubkeys and the invoice currency code. Set the following variables for your target network before running the commands below:\n\n```bash\n# For mainnet:\nNODE1_PUBKEY=\"03a8d7da8d0934363dbc17f52c872e8d833016415266eabb3527439c5dd17adc6b\"\nNODE2_PUBKEY=\"033a69e5be369dab43aefa96fa729d83c571ccb066f312136c6ab2d354fcc028f9\"\nCURRENCY=\"Fibb\"",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1176",
+      "id": "chunk-1194",
       "title": "public-nodes",
       "content": "# For testnet (uncomment and comment out the three lines above):\n# NODE1_PUBKEY=\"02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71\"\n# NODE2_PUBKEY=\"0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc\"\n# CURRENCY=\"Fibt\"\n```\n\n### Establishing a CKB Channel: nodeA ⟺ node1\n\n1. Connect nodeA to node1\n\n   ```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 1,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"connect_peer\",\n       \"params\": [\n           {\n               \"pubkey\": \"'$NODE1_PUBKEY'\"\n           }\n       ]\n   }'\n   ```\n\n   ```json\n   {\"jsonrpc\":\"2.0\",\"result\":null,\"id\":1}\n   ```\n\n2. Open a channel with 499 CKB: nodeA (400 CKB) ⟺ node1 (151 CKB)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1177",
+      "id": "chunk-1195",
       "title": "public-nodes",
       "content": "_Both mainnet and testnet node1 have `open_channel_auto_accept_min_ckb_funding_amount` set to 400 CKB, so please provide 499 CKB or more._\n\n   ```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 2,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"open_channel\",\n       \"params\": [\n           {\n               \"pubkey\": \"'$NODE1_PUBKEY'\",\n               \"funding_amount\": \"0xb9e459300\",\n               \"public\": true\n           }\n       ]\n   }'\n   ```\n\n   Example response:\n\n   ```json\n   {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"temporary_channel_id\":\"0x9b6811b43770f476a84662fa66779cc6008b10b0863af308148b3d0c9cbe03b7\"}}\n   ```\n\n3. Query channels and wait for `ChannelReady`",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1178",
+      "id": "chunk-1196",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 3,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"list_channels\",\n       \"params\": [\n           {\n               \"pubkey\": \"'$NODE1_PUBKEY'\"\n           }\n       ]\n   }'\n   ```\n\n   Wait until the `state_name` changes to `ChannelReady`.\n\n   **Note: If you attempt to call `send_payment` immediately after the channel enters the `ChannelReady` state, you may still encounter the error `Failed to build route`. Wait a moment and try again.**\n\n   Example response (testnet):",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1179",
+      "id": "chunk-1197",
       "title": "public-nodes",
       "content": "```json\n   {\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"channels\":[{\"channel_id\":\"0x8cfd1718dace307c1c7eee756773fee9ded3bae8a3808fc207e078ac5f190413\",\"is_public\":true,\"is_acceptor\":false,\"is_one_way\":false,\"channel_outpoint\":\"0x31b242023b98f2b460fc83cd0b9c3165c446bc129571dbc269d6e3f22d67b38600000000\",\"pubkey\":\"02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71\",\"funding_udt_type_script\":null,\"state\":{\"state_name\":\"ChannelReady\"},\"local_balance\":\"0x9502f9000\",\"offered_tlc_balance\":\"0x0\",\"remote_balance\":\"0x38407b700\",\"received_tlc_balance\":\"0x0\",\"pending_tlcs\":[],\"latest_commitment_transaction_hash\":\"0x586a486509015da605d403f184885c69c0a16e5e651e93d7e03a7f1a5378710a\",\"created_at\":\"0x19d72fe29f6\",\"enabled\":true,\"tlc_expiry_delta\":\"0xdbba00\",\"tlc_fee_proportional_millionths\":\"0x3e8\",\"shutdown_transaction_hash\":null,\"failure_detail\":null}]}}\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1180",
+      "id": "chunk-1198",
       "title": "public-nodes",
       "content": "`local_balance` is `0x9502f9000` (400 CKB) and `remote_balance` is `0x38407b700` (151 CKB). See [Channel Capacity](#channel-capacity) for why these differ from the funded amounts. Take note of these initial balances for comparison after payments.\n\n### Establishing a CKB Channel: nodeB ⟺ node2\n\n1. Connect nodeB to node2\n\n   ```bash\n   curl -s --location 'http://127.0.0.1:8237' --header 'Content-Type: application/json' --data '{\n       \"id\": 1,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"connect_peer\",\n       \"params\": [\n           {\n               \"pubkey\": \"'$NODE2_PUBKEY'\"\n           }\n       ]\n   }'\n   ```\n\n2. Open a channel with 499 CKB: nodeB (400 CKB) ⟺ node2 (151 CKB)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1181",
+      "id": "chunk-1199",
       "title": "public-nodes",
       "content": "_Node2 also has `open_channel_auto_accept_min_ckb_funding_amount` set to 400 CKB, so please provide 499 CKB or more._\n\n   ```bash\n   curl -s --location 'http://127.0.0.1:8237' --header 'Content-Type: application/json' --data '{\n       \"id\": 2,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"open_channel\",\n       \"params\": [\n           {\n               \"pubkey\": \"'$NODE2_PUBKEY'\",\n               \"funding_amount\": \"0xb9e459300\",\n               \"public\": true\n           }\n       ]\n   }'\n   ```\n\n3. Query channels and wait for `ChannelReady`",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1182",
+      "id": "chunk-1200",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8237' --header 'Content-Type: application/json' --data '{\n       \"id\": 3,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"list_channels\",\n       \"params\": [\n           {\n               \"pubkey\": \"'$NODE2_PUBKEY'\"\n           }\n       ]\n   }'\n   ```\n\n   Wait until the `state_name` changes to `ChannelReady`. Same as nodeA's channel: `local_balance` `0x9502f9000` (400 CKB), `remote_balance` `0x38407b700` (151 CKB).\n\n### Multi-Hop Payment: nodeA → node1 → node2 → nodeB",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1183",
+      "id": "chunk-1201",
       "title": "public-nodes",
       "content": "Now that both channels are established, we can send a multi-hop payment from nodeA to nodeB through the public nodes (see [Overview](#overview)). Since the RPC endpoints of node1 and node2 are not publicly accessible, we can only query balance changes on nodeA (port 8227) and nodeB (port 8237). The total fee charged by the intermediate nodes (node1 + node2) can be inferred from the difference.\n\n1. Generate an invoice on nodeB\n\n   Set the amount to 0x5f5e100 (100,000,000 shannon), equivalent to 1 CKB. The `payment_preimage` should be a unique 32-byte hex value.\n\n   ```bash\n   # Generate a 32-byte random number and represent it in hexadecimal\n   payment_preimage=\"0x$(openssl rand -hex 32)\"\n   echo $payment_preimage\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1184",
+      "id": "chunk-1202",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8237' --header 'Content-Type: application/json' --data '{\n       \"id\": 1,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"new_invoice\",\n       \"params\": [\n           {\n               \"amount\": \"0x5f5e100\",\n               \"currency\": \"'$CURRENCY'\",\n               \"description\": \"test invoice generated by nodeB\",\n               \"expiry\": \"0xe10\",\n               \"final_cltv\": \"0x28\",\n               \"payment_preimage\": \"'$payment_preimage'\",\n               \"hash_algorithm\": \"sha256\"\n           }\n       ]\n   }'\n   ```\n\n   Record the `invoice_address` from the response.\n\n   Example response (testnet):",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1185",
+      "id": "chunk-1203",
       "title": "public-nodes",
       "content": "```json\n   {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"invoice_address\":\"fibt1000000001p6s4agtplhxgfw0pnm6vknn46ej0nm48uyg8gfz86h906c6ju2sns33h4ugqwguntc0ls000wg5k2uw5agxseteza9r98uwveq5cglqvsfj0ukn8cdtytfswvs65usjnhxhfs5sqfc8hsz9d3sv4k07ssn8z8djpdu06fu8x8flf3gv9pmp4vzzn943k0cqrhm34yvdcfy5va275k9zt7rxl3vl4l8aqghkmvnpzlwypl79knrtksh2hqyfgshfl7hfswv4gw6xgqymrl0g0t64pjm32p9qd80e2nm8ge3fnlpv4mrn5y3nw8mpl04htsv7js39tf3lyu60r4z5yslxcvepgdgmgph03hsz3l7upeqna955sqv34m0s\",\"invoice\":{\"currency\":\"Fibt\",\"amount\":\"0x5f5e100\",\"signature\":\"041b031f0f080f0b1a1501121b110a0105000d070f190a131b0708191109131f010c151b0313140411130e071b011f0f15170b100c1e121011050b09111f041c1a0f0315021404101f06180c1901080d081b0801170f11171002111f1e1c011900131d0514141000\",\"data\":{\"timestamp\":\"0x19d7301e572\",\"payment_hash\":\"0x7d3966a6cc741c21d1a65e707ba876ca1226e23e7e1335ddb8d2e9b1c5f2cc14\",\"attrs\":[{\"description\":\"test invoice generated by nodeB\"},{\"expiry_time\":\"0xe10\"},{\"final_htlc_minimum_expiry_delta\":\"0x927c00\"},{\"hash_algorithm\":\"sha256\"},{\"payee_public_key\":\"02e92cbef1c29a8c49eff0148a92e044a484f2d28ffd98aed72c630e441d4a1a25\"}]}}}}\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1186",
+      "id": "chunk-1204",
       "title": "public-nodes",
       "content": "2. Send payment from nodeA to nodeB\n\n   Pass in the previously recorded `invoice_address` to the `send_payment` request on nodeA\n\n   ```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 2,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"send_payment\",\n       \"params\": [\n           {\n               \"invoice\": \"<invoice_address from step 1>\"\n           }\n       ]\n   }'\n   ```\n\n   Example response (testnet):\n\n   ```json\n   {\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"payment_hash\":\"0x7d3966a6cc741c21d1a65e707ba876ca1226e23e7e1335ddb8d2e9b1c5f2cc14\",\"status\":\"Created\",\"created_at\":\"0x19d730291e3\",\"last_updated_at\":\"0x19d730291e3\",\"failed_error\":null,\"fee\":\"0x30da4\",\"custom_records\":null}\n   ```\n\n3. Repeat Steps 1 and 2 two more times",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1187",
+      "id": "chunk-1205",
       "title": "public-nodes",
       "content": "Perform two additional `new_invoice` (on nodeB) and `send_payment` (on nodeA) requests, keeping the amount set to 0x5f5e100.\n\n4. Query channel balances after payments\n\n   nodeA ⟺ node1\n\n   Balances changed from `{\"local_balance\":\"0x9502f9000\",\"remote_balance\":\"0x38407b700\"}` to `{\"local_balance\":\"0x93e44c414\",\"remote_balance\":\"0x395f282ec\"}`\n\n   nodeB ⟺ node2\n\n   Balances changed from `{\"local_balance\":\"0x9502f9000\",\"remote_balance\":\"0x38407b700\"}` to `{\"local_balance\":\"0x962113300\",\"remote_balance\":\"0x372261400\"}`\n\nThis means the channel balances have changed as follows before and after the payments:\n\n- Before payments\n\n  nodeA (40000000000) ⟺ node1 (15100000000)\n\n  nodeB (40000000000) ⟺ node2 (15100000000)\n\n- After payments\n\n  nodeA (39699399700) ⟺ node1 (15400600300)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1188",
+      "id": "chunk-1206",
       "title": "public-nodes",
       "content": "nodeB (40300000000) ⟺ node2 (14800000000)\n\nFunds changes:\n\n​\tnodeA: 39699399700 - 40000000000 = -300600300\n\n​\tnodeB: 40300000000 - 40000000000 = +300000000\n\n​\tTotal intermediate fees (node1 + node2): 300600300 - 300000000 = 600300\n\n**Conclusion: Three CKB payments of 100,000,000 shannon (1 CKB) each from nodeA → node1 → node2 → nodeB were successfully completed. nodeA paid a total of 300,600,300 shannon, nodeB received 300,000,000 shannon, and the two intermediate relay nodes (node1 + node2) earned a combined fee of 600,300 shannon.**\n\n5. Close the channels\n\n   Replace `<channel_id_a>` and `<channel_id_b>` with the `channel_id` values from the `list_channels` responses above.\n\n   Close nodeA's channel with node1:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1189",
+      "id": "chunk-1207",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 5,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"shutdown_channel\",\n       \"params\": [\n           {\n               \"channel_id\": \"<channel_id_a>\",\n               \"close_script\": {\n                   \"code_hash\": \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n                   \"hash_type\": \"type\",\n                   \"args\": \"<lock_arg_a>\"\n               },\n               \"fee_rate\": \"0x3FC\"\n           }\n       ]\n   }'\n   ```\n\n   ```json\n   {\"jsonrpc\":\"2.0\",\"result\":null,\"id\":5}\n   ```\n\n   Close nodeB's channel with node2:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1190",
+      "id": "chunk-1208",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8237' --header 'Content-Type: application/json' --data '{\n       \"id\": 5,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"shutdown_channel\",\n       \"params\": [\n           {\n               \"channel_id\": \"<channel_id_b>\",\n               \"close_script\": {\n                   \"code_hash\": \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n                   \"hash_type\": \"type\",\n                   \"args\": \"<lock_arg_b>\"\n               },\n               \"fee_rate\": \"0x3FC\"\n           }\n       ]\n   }'\n   ```\n\n   ```json\n   {\"jsonrpc\":\"2.0\",\"result\":null,\"id\":5}\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1191",
+      "id": "chunk-1209",
       "title": "public-nodes",
       "content": "After channel closure, the on-chain settlement will reflect the final balances. You can verify on the CKB explorer that:\n    - nodeA's address received CKB reflecting its remaining channel balance\n    - nodeB's address received CKB reflecting its accumulated payments\n\n---\n\n## Testnet: UDT (RUSD) Payment\n\nMainnet public nodes do not hold any USDI yet, so UDT channels cannot be created at this time. This section only covers the testnet.\n\nOn testnet, node2 exposes a public RPC endpoint (including `new_invoice`), so for simplicity this demo uses the path nodeA → node1 → node2. Only nodeA is needed.\n\n### Establishing a UDT Channel: nodeA ⟺ node1\n\n1. Connect nodeA to node1",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1192",
+      "id": "chunk-1210",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 1,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"connect_peer\",\n       \"params\": [\n           {\n               \"pubkey\": \"02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71\"\n           }\n       ]\n   }'\n   ```\n\n2. Open a UDT channel with 20 RUSD: nodeA (20 RUSD) ⟺ node1 (0 RUSD)\n\n   _Node1 has `auto_accept_amount` for RUSD set to 20 RUSD, so please provide 20 RUSD or more as the funding_amount._",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1193",
+      "id": "chunk-1211",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 2,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"open_channel\",\n       \"params\": [\n           {\n               \"pubkey\": \"02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71\",\n               \"funding_amount\": \"0x77359400\",\n               \"public\": true,\n               \"funding_udt_type_script\": {\n                   \"code_hash\": \"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\n                   \"hash_type\": \"type\",\n                   \"args\": \"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"\n               }\n           }\n       ]\n   }'\n   ```\n\n3. Query channels and wait for `ChannelReady`",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1194",
+      "id": "chunk-1212",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 3,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"list_channels\",\n       \"params\": [\n           {\n               \"pubkey\": \"02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71\"\n           }\n       ]\n   }'\n   ```\n\n   Example response:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1195",
+      "id": "chunk-1213",
       "title": "public-nodes",
       "content": "```json\n   {\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"channels\":[{\"channel_id\":\"0x19380f65a48f88bf69dd07336f231655a183e01bba304485d0fed6a428f329d3\",\"is_public\":true,\"is_acceptor\":false,\"is_one_way\":false,\"channel_outpoint\":\"0x34efee5b56b48b314d3d75870db4921f34b226d2b224e02bb9d89d3ee77d791c00000000\",\"pubkey\":\"02b6d4e3ab86a2ca2fad6fae0ecb2e1e559e0b911939872a90abdda6d20302be71\",\"funding_udt_type_script\":{\"code_hash\":\"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\"hash_type\":\"type\",\"args\":\"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"},\"state\":{\"state_name\":\"ChannelReady\"},\"local_balance\":\"0x77359400\",\"offered_tlc_balance\":\"0x0\",\"remote_balance\":\"0x0\",\"received_tlc_balance\":\"0x0\",\"pending_tlcs\":[],\"latest_commitment_transaction_hash\":\"0x9c254a1a8f4be0be28256072568c3490cc1dedb0e2dd1f63ff05b1e5ddf7a10f\",\"created_at\":\"0x19d72cb19f4\",\"enabled\":true,\"tlc_expiry_delta\":\"0xdbba00\",\"tlc_fee_proportional_millionths\":\"0x3e8\",\"shutdown_transaction_hash\":null,\"failure_detail\":null}]}}\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1196",
+      "id": "chunk-1214",
       "title": "public-nodes",
       "content": "Filter the response for entries where `funding_udt_type_script` is not null. You should see `local_balance` of `0x77359400` (20 RUSD) and `remote_balance` of `0x0` (0 RUSD). Take note of these initial balances for comparison after payments.\n\n### Payment: nodeA → node1 → node2\n\n1. Use `graph_nodes` to discover node2's current IP\n\n   ```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 1,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"graph_nodes\",\n       \"params\": [\n           {}\n       ]\n   }'\n   ```\n\n   Then find the entry whose `pubkey` matches `$NODE2_PUBKEY`.\n\n   Example response excerpt:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1197",
+      "id": "chunk-1215",
       "title": "public-nodes",
       "content": "```json\n   {\"node_name\":\"CkbaNode-2\",\"version\":\"0.8.0\",\"addresses\":[\"/ip4/18.163.221.211/tcp/8119/p2p/QmbKyzq9qUmymW2Gi8Zq7kKVpPiNA1XUJ6uMvsUC4F3p89\"],\"features\":[\"GOSSIP_QUERIES_REQUIRED\",\"BASIC_MPP_REQUIRED\",\"TRAMPOLINE_ROUTING_REQUIRED\"],\"pubkey\":\"0291a6576bd5a94bd74b27080a48340875338fff9f6d6361fe6b8db8d0d1912fcc\",\"timestamp\":\"0x19d776bd919\",\"chain_hash\":\"0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606\",\"auto_accept_min_ckb_funding_amount\":\"0x9502f9000\",\"udt_cfg_infos\":[{\"name\":\"RUSD\",\"script\":{\"code_hash\":\"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\"hash_type\":\"type\",\"args\":\"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"},\"auto_accept_amount\":\"0x77359400\",\"cell_deps\":[{\"type_id\":{\"code_hash\":\"0x00000000000000000000000000000000000000000000000000545950455f4944\",\"hash_type\":\"type\",\"args\":\"0x97d30b723c0b2c66e9cb8d4d0df4ab5d7222cbb00d4a9a2055ce2e5d7f0d8b0f\"}}]}]}\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1198",
+      "id": "chunk-1216",
       "title": "public-nodes",
       "content": "Using the IP from the entry above, construct the RPC endpoint with the default port `8227`:\n\n   ```bash\n   NODE2_RPC=\"http://18.163.221.211:8227\"\n   ```\n\n2. Generate an invoice on node2\n\n   Set the amount to 0x5f5e100 (100,000,000), which is equivalent to 1 RUSD.\n\n   Here, a unique payment_preimage is still required. You can generate one using: `payment_preimage=\"0x$(openssl rand -hex 32)\"`",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1199",
+      "id": "chunk-1217",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location \"$NODE2_RPC\" --header 'Content-Type: application/json' --data '{\n       \"id\": 2,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"new_invoice\",\n       \"params\": [\n           {\n               \"amount\": \"0x5f5e100\",\n               \"currency\": \"Fibt\",\n               \"description\": \"test invoice generated by node2\",\n               \"expiry\": \"0xe10\",\n               \"final_cltv\": \"0x28\",\n               \"payment_preimage\": \"'$payment_preimage'\",\n               \"hash_algorithm\": \"sha256\",\n               \"udt_type_script\": {\n                   \"code_hash\": \"0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a\",\n                   \"hash_type\": \"type\",\n                   \"args\": \"0x878fcc6f1f08d48e87bb1c3b3d5083f23f8a39c5d5c764f253b55b998526439b\"\n               }\n           }\n       ]\n   }'\n   ```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1200",
+      "id": "chunk-1218",
       "title": "public-nodes",
       "content": "Record the `invoice_address` from the response.\n\n3. Send payment from nodeA\n\n   ```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 3,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"send_payment\",\n       \"params\": [\n           {\n               \"invoice\": \"<invoice_address from step 2>\"\n           }\n       ]\n   }'\n   ```\n\n4. Repeat Steps 2 and 3 two more times\n\n   Perform two additional `new_invoice` (on node2) and `send_payment` (on nodeA) requests, keeping the amount set to 0x5f5e100.\n\n5. Query channel balances after payments\n\n   nodeA ⟺ node1\n\n   Balances changed from `{\"local_balance\":\"0x77359400\",\"remote_balance\":\"0x0\"}` to `{\"local_balance\":\"0x654f5d20\",\"remote_balance\":\"0x11e636e0\"}`",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1201",
+      "id": "chunk-1219",
       "title": "public-nodes",
       "content": "This means the channel balances have changed as follows:\n\n- Before payments\n\n  nodeA (2000000000) ⟺ node1 (0)\n\n- After payments\n\n  nodeA (1699700000) ⟺ node1 (300300000)\n\nFunds changes:\n\n​\tnodeA: 1699700000 - 2000000000 = -300300000\n\n​\tnode1 earned fee: 300300000 - 300000000 = 300000\n\n​\tnode2 received: 300000000\n\n**Conclusion: Three UDT payments of 100,000,000 (1 RUSD) each from nodeA → node1 → node2 were successfully completed. The intermediate node (node1) earned a total fee of 300,000 (0.003 RUSD).**\n\n6. Close the UDT channel\n\n   Replace `<channel_id>` with the `channel_id` from the `list_channels` response.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1202",
+      "id": "chunk-1220",
       "title": "public-nodes",
       "content": "```bash\n   curl -s --location 'http://127.0.0.1:8227' --header 'Content-Type: application/json' --data '{\n       \"id\": 6,\n       \"jsonrpc\": \"2.0\",\n       \"method\": \"shutdown_channel\",\n       \"params\": [\n           {\n               \"channel_id\": \"<channel_id>\",\n               \"close_script\": {\n                   \"code_hash\": \"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8\",\n                   \"hash_type\": \"type\",\n                   \"args\": \"<lock_arg_a>\"\n               },\n               \"fee_rate\": \"0x3FC\"\n           }\n       ]\n   }'\n   ```\n\n   You can verify on the CKB explorer that nodeA's address received a settlement transaction reflecting its remaining RUSD balance.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/public-nodes.md",
       "source": "public-nodes.md"
     },
     {
-      "id": "chunk-1203",
+      "id": "chunk-1221",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "# Integer Overflow in Onion Packet Deserialization\n\n## Problem Statement\n\nAn integer overflow vulnerability was discovered in the onion packet deserialization code. When parsing untrusted network input, the `get_hop_data_len` function read a `u64` length value from bytes, cast it directly to `usize`, and added `HOP_DATA_HEAD_LEN` (8) without overflow protection.\n\n### Attack Vector\n\nAn attacker could send a malicious onion packet with `0xFFFFFFFFFFFFFFFF` (u64::MAX) in the 8-byte length header, causing:\n\n1. **On 64-bit platforms**: Integer overflow when adding 8, wrapping to 7\n2. **On 32-bit platforms**: Truncation during the `as usize` cast\n3. **Result**: Panic (DoS) from failed bounds checks, or incorrect parsing if the overflowed length happens to pass validation",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1204",
+      "id": "chunk-1222",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "Note: Rust's safe slice operations prevent actual out-of-bounds memory access; invalid indices result in a panic rather than memory corruption.\n\n### Vulnerable Code\n\n```rust\n// VULNERABLE: types.rs:4079-4091 (before fix)\nfn get_hop_data_len(buf: &[u8]) -> Option<usize> {\n    if buf.len() < HOP_DATA_HEAD_LEN {\n        return None;\n    }\n    Some(\n        u64::from_be_bytes(\n            buf[0..HOP_DATA_HEAD_LEN].try_into().expect(\"u64 from slice\"),\n        ) as usize        // ← Unsafe cast!\n            + HOP_DATA_HEAD_LEN,  // ← Unchecked addition!\n    )\n}\n```\n\n## Solution\n\n### Fix 1: `len_with_u64_header` Function\n\n**Location**: `crates/fiber-lib/src/fiber/types.rs`\n\nThe function was refactored to support versioned hop data formats. The v0 format uses the original u64 BE length header:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1205",
+      "id": "chunk-1223",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "```rust\n/// Returns the total length with u64 BE header: [u64 BE length] + data.\n/// Used by v0 format (Trampoline and legacy payment hop data).\nfn len_with_u64_header(buf: &[u8]) -> Option<usize> {\n    if buf.len() < HOP_DATA_HEAD_LEN {\n        return None;\n    }\n    let len = u64::from_be_bytes(\n        buf[0..HOP_DATA_HEAD_LEN]\n            .try_into()\n            .expect(\"u64 from slice\"),\n    );\n    // Safe conversion: check value fits in usize and addition won't overflow.\n    // Note: Caller (fiber-sphinx) is responsible for validating len against packet bounds.\n    usize::try_from(len).ok()?.checked_add(HOP_DATA_HEAD_LEN)\n}\n```\n\n**Why this works:**",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1206",
+      "id": "chunk-1224",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "1. `usize::try_from(len)` - Returns `None` if value exceeds `usize::MAX` (handles 32-bit platforms)\n2. `.ok()?` - Propagates the `None` on conversion failure\n3. `.checked_add(HOP_DATA_HEAD_LEN)` - Returns `None` if addition would overflow\n\n### Fix 2: Version Validation in `peel_sphinx_onion`\n\n**Location**: `crates/fiber-lib/src/fiber/types.rs`\n\nThe onion packet peeling logic now validates version before processing:\n\n```rust\nlet version = sphinx_packet.version;\nif !Codec::is_version_allowed(version) {\n    return Err(Error::OnionPacket(OnionPacketError::UnknownVersion(version)));\n}\n```\n\nAdditionally, the version-aware unpacking functions (`unpack_hop_data`, `hop_data_len`) now explicitly match known versions and return `None` for unknown versions, preventing silent misparsing:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1207",
+      "id": "chunk-1225",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "```rust\npub(crate) fn unpack_hop_data(version: u8, buf: &[u8]) -> Option<PaymentHopData> {\n    match version {\n        ONION_PACKET_VERSION_V0 => { /* ... */ }\n        ONION_PACKET_VERSION_V1 => { /* ... */ }\n        _ => None,  // Reject unknown versions\n    }\n}\n```\n\n**Why this works:**\n\n- Unknown versions are explicitly rejected at the version check\n- Defense in depth: unpacking functions also reject unknown versions\n- Clear error handling prevents silent misparsing of malformed packets\n\n### Test Coverage Added\n\n**Location**: `crates/fiber-lib/src/fiber/tests/types.rs`\n\nTests are organized by version (v0/v1) with separate functions for independent failure tracking:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1208",
+      "id": "chunk-1226",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "| Test Function | Input | Expected |\n|---------------|-------|----------|\n| `test_unpack_hop_data_v0_empty_input` | `[]` | None (too short) |\n| `test_unpack_hop_data_v0_u64_max_overflow` | `[0xFF × 8, 0x00]` | None (overflow) |\n| `test_unpack_hop_data_v0_large_claimed_length` | 1000 bytes claimed | None (bounds) |\n| `test_unpack_hop_data_v0_short_header` | 7 bytes | None (need 8) |\n| `test_unpack_hop_data_v0_exceeds_buffer` | 6501 claimed | None (bounds) |\n| `test_unpack_hop_data_v0_near_max_overflow` | `usize::MAX - 7` | None (overflow) |\n| `test_unpack_hop_data_v1_empty_input` | `[]` | None (too short) |\n| `test_unpack_hop_data_v1_short_header` | 3 bytes | None (need 4) |\n| `test_unpack_hop_data_v1_large_claimed_length` | 1000 bytes claimed | None (bounds) |\n| `test_payment_onion_packet_peel_unknown_version` | version=99 | Error (unknown) |",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1209",
+      "id": "chunk-1227",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "```rust\n#[test]\nfn test_unpack_hop_data_v0_u64_max_overflow() {\n    // v0 format: [u64 BE length header with u64::MAX]\n    // Length header is u64::MAX, which would cause overflow when adding HOP_DATA_HEAD_LEN\n    let malicious_input = [255u8, 255, 255, 255, 255, 255, 255, 255, 0];\n    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &malicious_input);\n    assert!(result.is_none(), \"Should reject input with overflow-causing length\");\n}\n\n// ... additional version-specific test functions\n```\n\n## Prevention Guidelines\n\n### Code Review Checklist\n\nWhen reviewing Rust network parsing code, flag these patterns:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1210",
+      "id": "chunk-1228",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "- [ ] `as usize` after `from_be_bytes`/`from_le_bytes` - Use `usize::try_from()` instead\n- [ ] Unchecked arithmetic on parsed values - Use `checked_add`/`checked_sub`/`checked_mul`\n- [ ] Slice access using parsed indices - Validate bounds first\n- [ ] Missing validation on network input - Always validate before use\n\n### Safe Patterns\n\n```rust\n// ❌ VULNERABLE\nlet len = u64::from_be_bytes(bytes) as usize;\nlet offset = parsed_value + CONSTANT;\n\n// ✅ SAFE\nlet len = usize::try_from(u64::from_be_bytes(bytes)).ok()?;\nlet offset = parsed_value.checked_add(CONSTANT)?;\n```\n\n### Testing Recommendations",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1211",
+      "id": "chunk-1229",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "1. **Fuzz testing**: Use `cargo-fuzz` on all packet parsing functions\n2. **Boundary tests**: Test with `u64::MAX`, `usize::MAX`, `0`, near-max values\n3. **Platform tests**: Run tests on both 32-bit and 64-bit targets in CI\n\n## Related Patterns to Review\n\nThe following locations use similar byte parsing patterns and should be audited:\n\n| Location | Pattern | Risk |\n|----------|---------|------|\n| `watchtower/actor.rs:267` | `u64::from_be_bytes` | Low (blockchain data) |\n| `watchtower/actor.rs:802-804` | `u64::from_le_bytes` | Low (blockchain data) |\n| `watchtower/actor.rs:1576` | `u64::from_le_bytes` (htlc_expiry) | Medium (witness data) |\n| `store/store_impl/mod.rs:212` | `u64::from_le_bytes` | Low (internal DB keys) |\n\n## References",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1212",
+      "id": "chunk-1230",
       "title": "Integer Overflow in Onion Packet Deserialization",
       "content": "- **PR**: [#1094](https://github.com/nervosnetwork/fiber/pull/1094)\n- **Commit**: `88ce3831 fix: prevent integer overflow in onion packet deserialization`\n- **Related specs**: [P2P Message Protocol](../../specs/p2p-message.md)\n- **Glossary**: [Onion Routing](../../glossary.md)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md",
       "source": "solutions/security-issues/integer-overflow-onion-packet-deserialization.md"
     },
     {
-      "id": "chunk-1213",
+      "id": "chunk-1231",
       "title": "cch-expiry-dependency",
       "content": "# CCH Expiry Dependency\n\nFor CCH to complete a swap successfully, the incoming payment must leave sufficient expiry time for the outgoing payment to settle.\n\n## Configuration Options\n\nCCH config provides the following options:\n\n- **`btc_final_tlc_expiry_delta_blocks`**: The minimum final CLTV expiry used when creating the incoming invoice in LND.\n- **`ckb_final_tlc_expiry_delta_seconds`**: The minimum final TLC expiry used when creating the incoming invoice in Fiber.\n- **`min_outgoing_invoice_expiry_delta_seconds`**: The minimum remaining time before the outgoing invoice expires. CCH will reject swaps if the outgoing invoice expires sooner than this threshold.\n\n## Default Behavior",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cch-expiry-dependency.md",
       "source": "specs/cch-expiry-dependency.md"
     },
     {
-      "id": "chunk-1214",
+      "id": "chunk-1232",
       "title": "cch-expiry-dependency",
       "content": "The default values for the first two options ensure a 30-hour window to settle the outgoing payment. This relies on LND and Fiber verifying that the final TLC expiry time meets the configured threshold specified in the invoice.\n\n## Outgoing Invoice Final Expiry Validation\n\nCCH validates that the outgoing invoice's final CLTV/TLC expiry is less than half of the configured expiry for the incoming invoice. This ensures the CCH operator has sufficient time to settle the incoming side before the outgoing side expires.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cch-expiry-dependency.md",
       "source": "specs/cch-expiry-dependency.md"
     },
     {
-      "id": "chunk-1215",
+      "id": "chunk-1233",
       "title": "cch-expiry-dependency",
       "content": "- **SendBTC** (Fiber → Lightning): The BTC invoice's `min_final_cltv_expiry_delta` (converted to seconds assuming 10 min/block) must be less than `ckb_final_tlc_expiry_delta_seconds / 2`.\n- **ReceiveBTC** (Lightning → Fiber): The Fiber invoice's `final_tlc_minimum_expiry_delta` must be less than `btc_final_tlc_expiry_delta_blocks / 2` (converted to milliseconds).\n\nIf this validation fails, the swap is rejected with an error indicating the final expiry delta exceeds the safe limit for cross-chain swaps.\n\n## Outgoing Payment Route Expiry Check",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cch-expiry-dependency.md",
       "source": "specs/cch-expiry-dependency.md"
     },
     {
-      "id": "chunk-1216",
+      "id": "chunk-1234",
       "title": "cch-expiry-dependency",
       "content": "The static validation above only compares the **final** expiry deltas, which represent the minimum expiry at the last hop. However, when the outgoing payment is routed through multiple intermediate nodes, each hop adds its own expiry delta. The total route expiry at the first hop can be significantly larger than the final expiry delta alone.\n\nTo prevent fund loss from this scenario, CCH performs a dynamic expiry check when dispatching the outgoing payment (after the incoming payment is accepted):\n\n1. **Compute remaining incoming time**: `incoming_final_expiry_delta - (now - order.created_at)`. This is a conservative lower bound on the incoming TLC/HTLC's remaining time, since the TLC was accepted at or after order creation.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cch-expiry-dependency.md",
       "source": "specs/cch-expiry-dependency.md"
     },
     {
-      "id": "chunk-1217",
+      "id": "chunk-1235",
       "title": "cch-expiry-dependency",
       "content": "2. **Allocate half for outgoing**: The maximum allowed outgoing route expiry is `remaining / 2`. The other half is reserved for CCH to settle the incoming payment after receiving the preimage.\n\n3. **Validate sufficiency**: If the allocated time is less than the outgoing invoice's minimum final expiry delta, the order is failed immediately — routing is impossible without exceeding the safe limit.\n\n4. **Cap the outgoing route**: The computed limit is enforced on the outgoing payment:\n   - **BTC (LND)**: Set `cltv_limit` on `SendPaymentRequest` to `max_outgoing_seconds / 600` blocks.\n   - **CKB (Fiber)**: Set `tlc_expiry_limit` on `SendPaymentCommand` to `max_outgoing_seconds * 1000` milliseconds.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cch-expiry-dependency.md",
       "source": "specs/cch-expiry-dependency.md"
     },
     {
-      "id": "chunk-1218",
+      "id": "chunk-1236",
       "title": "cch-expiry-dependency",
       "content": "This ensures that even in the worst case — where the outgoing payment settles at the very last moment before its route expiry — CCH still has enough time to settle the incoming payment.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cch-expiry-dependency.md",
       "source": "specs/cch-expiry-dependency.md"
     },
     {
-      "id": "chunk-1219",
+      "id": "chunk-1237",
       "title": "cross-chain-htlc",
       "content": "# Payment Channel Cross-Chain Protocol with HTLC\n\n## Synopsis\n\nIn the rapidly evolving world of blockchain technology, interoperability between different networks is becoming increasingly crucial. One of the most promising solutions to this challenge is the use of payment channel cross-chain protocols based on Hash Time-Locked Contracts (HTLCs). This post will delve into how HTLCs can be used to ensure atomic payments across different blockchain networks using the same preimage.\n\n## What is HTLC?\n\nHash Time-Locked Contracts (HTLCs) are a type of smart contract used to facilitate conditional payments. They are designed to ensure that a transaction is either completed within a specified timeframe or canceled. The key components of an HTLC are:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1220",
+      "id": "chunk-1238",
       "title": "cross-chain-htlc",
       "content": "1. **Hashlock**: A cryptographic hash of a secret (preimage) that must be revealed to complete the transaction.\n2. **Timelock**: A time constraint that ensures the transaction is either completed within a certain period or reverted.\n\n## Cross-Chain Payments with HTLC\n\nCross-chain payments involve transferring value across different blockchain networks, which can be difficult due to the absence of direct interoperability. To address this challenge, Hashed Time Lock Contracts (HTLCs) offer a solution by facilitating atomic swaps. These swaps guarantee that transactions are either executed in full or not at all, eliminating the possibility of partial transfers.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1221",
+      "id": "chunk-1239",
       "title": "cross-chain-htlc",
       "content": "To ensure stability in cross-chain payments, the assets utilized in different blockchain networks must maintain a fixed swap ratio. For instance, the Bitcoin payment channel exclusively supports BTC. Meanwhile, CKB can incorporate a wrapped BTC token via the UDT channel, establishing a consistent 1:1 ratio with Bitcoin.\n\nAnother requirement is that the two networks must use the same hash algorithm for HTLCs.\n\n## Specification\n\nThe protocol has three actors:\n\n- Alice in the Blockchain A who wants to send funds to Bob.\n- Bob in the Blockchain B who wants to receive funds from Alice.\n- Ingrid is the cross-chain hub service provider who runs the payment channel nodes for both Blockchain A and Blockchain B.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1222",
+      "id": "chunk-1240",
       "title": "cross-chain-htlc",
       "content": "To understand how HTLCs can be used for cross-chain payments, let's break down the process:\n\n1. **Negotiating**:\n   - Bob wants to receive $N_b$ amount of asset $T_b$ in the Blockchain B.\n   - Alice negotiates with Ingrid that if Alice pays $N_a$ amount of asset $T_a$ in the Blockchain A to Ingrid, Ingrid will send $N_b$ amount of asset $T_b$ to Bob in the Blockchain B.\n\n2. **Offering HTLCs**:\n   - Alice offers an HTLC with $N_a$ amount of $T_a$ on Blockchain A to Ingrid, locking her funds with a hashlock and a timelock. The hashlock is derived from a secret preimage $S$ that only Bob knows.\n   - Ingrid, upon receiving the hashlock from Alice, creates a corresponding HTLC on Blockchain B with $N_b$ amount of $T_b$, locking his funds with the same hashlock and a timelock.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1223",
+      "id": "chunk-1241",
       "title": "cross-chain-htlc",
       "content": "3. **Revealing the Preimage**:\n   - To claim the funds on Blockchain B, Bob must reveal the preimage to Ingrid.\n   - Once Ingrid has the preimage, he can use it to unlock the funds on Blockchain A.\n   - Both transactions are completed atomically, meaning either both are completed, or neither is.\n\nThe process can be extended to routed payments in both Blockchain A and B.\n\n## Example Between Bitcoin and CKB\n\n### Setup",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1224",
+      "id": "chunk-1242",
       "title": "cross-chain-htlc",
       "content": "- Alice is in the Blockchain CKB and runs a FNN (Fiber Network Node).\n- Bob is in the Blockchain Bitcoin and runs any BOLT compatible lightning node.\n- Ingrid is the cross-chain hub service provider who runs both a FNN in CKB and a BOLT lighting node in Bitcoin.\n- The asset used in Blockchain Bitcoin ($T_b$) is BTC.\n- Ingrid configures a UDT asset $T_a$ in CKB as the wrapped BTC.\n\n### From CKB to Bitcoin\n\n- Bob wants to receive $X$ BTC in Bitcoin.\n- Alice negotiates the swap with Ingrid that if Alice sends $X+F$ wrapped BTC in CKB to Ingrid, Ingrid with send $X$ BTC in Bitcoin to Bob. Ingrid will keep $F$ BTC as the fee.\n\n### From Bitcoin to CKB",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1225",
+      "id": "chunk-1243",
       "title": "cross-chain-htlc",
       "content": "- Alice wants to receive $X$ wrapped BTC in CKB.\n- Alice negotiates the swap with Ingrid that if Bob sends $X+F$ BTC in Bitcoin to Ingrid, Ingrid with send $X$ wrapped BTC in CKB to Alice. Ingrid will keep $F$ wrapped BTC as the fee.\n\n## Benefits of Using HTLC for Cross-Chain Payments",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1226",
+      "id": "chunk-1244",
       "title": "cross-chain-htlc",
       "content": "1. **Security**: The use of cryptographic hash functions ensures that the transactions are secure and tamper-proof.\n2. **Atomicity**: The all-or-nothing nature of HTLCs ensures that funds are not lost or stuck in limbo.\n3. **Interoperability**: HTLCs enable seamless value transfer between different blockchain networks without the need for a trusted third party.\n4. **Compatibility**: The HTLC cross-chain protocol can seamlessly integrate with the existing Bitcoin payment channel network without requiring any modifications.\n\n## Future Works",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1227",
+      "id": "chunk-1245",
       "title": "cross-chain-htlc",
       "content": "While HTLCs have proven to be a valuable tool for enabling secure cross-chain payments, future research is exploring the potential of Point Time-Locked Contracts (PTLCs) as an improvement over the current HTLC design. PTLCs replace the hash function used in HTLCs with a public key cryptography scheme, offering several advantages:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1228",
+      "id": "chunk-1246",
       "title": "cross-chain-htlc",
       "content": "- Improved privacy: PTLCs hide the payment hash, making it more difficult for observers to link payments across different hops in the network.\n- Reduced on-chain footprint: By using adaptor signatures, PTLCs can reduce the amount of data that needs to be stored on-chain, leading to lower transaction fees and improved scalability.\n- Enhanced security: PTLCs are less vulnerable to certain types of attacks, such as the wormhole attack, which can be used to steal funds in HTLC-based payment channels.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1229",
+      "id": "chunk-1247",
       "title": "cross-chain-htlc",
       "content": "Migrating from HTLCs to PTLCs could potentially unlock new possibilities for cross-chain protocols, enabling more private, efficient, and secure value transfer across different blockchain networks. As the technology matures and wildly adopted in Bitcoin, it is likely that more projects will explore the use of PTLCs to enhance their cross-chain payment capabilities and drive further innovation in the blockchain ecosystem.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/cross-chain-htlc.md",
       "source": "specs/cross-chain-htlc.md"
     },
     {
-      "id": "chunk-1230",
+      "id": "chunk-1248",
       "title": "p2p-message",
       "content": "# Fiber Network P2P Message Protocol\n\nThis document describes the protocol between nodes of the fiber network on CKB, used to establish payment channels, construct transactions, close channels, and perform payment operations. Essentially, it is an adaptation and simplification of [BOLT 02] to suit the transaction structure of CKB.\n\nPlease note that BOLT 02 uses HTLC (Hashed Time Locked Contract) for payment operations, and many message definitions use HTLC as field names and descriptions. In this document, we will use TLC instead of HTLC to facilitate future support for PTLC (Point Time Locked Contract). Additionally, this protocol will use [Molecule] to define message formats, making it easier to integrate with CKB.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1231",
+      "id": "chunk-1249",
       "title": "p2p-message",
       "content": "***This document is a work in progress and may be updated at any time.***\n\n## Channel Establishment\n\nWe use a protocol similar to BOLTS 02 Channel Establishment v2 to establish payment channels, an example process is as follows:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1232",
+      "id": "chunk-1250",
       "title": "p2p-message",
       "content": "```\n    +-------+                              +-------+\n    |       |--(1)--- OpenChannel     ---->|       |\n    |       |<-(2)--- AcceptChannel   -----|       |\n    |       |                              |       |\n--->|       |      <tx collaboration>      |       |\n|   |       |                              |       |\n|   |       |--(3)--  commitment_signed -->|       |\n|   |       |<-(4)--  commitment_signed ---|       |\n|   |   A   |                              |   B   |\n|   |       |<-(5)--  tx_signatures -------|       |\n|   |       |--(6)--  tx_signatures ------>|       |\n|   |       |                              |       |\n|   |       |--(a)--- tx_init_rbf -------->|       |\n----|       |<-(b)--- tx_ack_rbf ----------|       |\n    |       |                              |       |\n    |       |    <tx rbf collaboration>    |       |\n    |       |                              |       |\n    |       |--(c)--  commitment_signed -->|       |\n    |       |<-(d)--  commitment_signed ---|       |\n    |       |                              |       |\n    |       |<-(e)--  tx_signatures -------|       |\n    |       |--(f)--  tx_signatures ------>|       |\n    |       |                              |       |\n    |       |--(7)--- channel_ready  ----->|       |\n    |       |<-(8)--- channel_ready  ------|       |\n    +-------+                              +-------+",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1233",
+      "id": "chunk-1251",
       "title": "p2p-message",
       "content": "- where node A is *opener*/*initiator* and node B is\n      *accepter*/*non-initiator*\n```\n### OpenChannel\n\n`OpenChannel` is sent by the initiator of the channel to the receiver of the channel to request the establishment of a payment channel.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1234",
+      "id": "chunk-1252",
       "title": "p2p-message",
       "content": "```\ntable OpenChannel {\n    chain_hash:                  Byte32,\n    channel_id:                  Byte32,\n    funding_type_script:         ScriptOpt,\n    funding_amount:              Uint128,\n    funding_fee_rate:            Uint64,\n    commitment_fee_rate:         Uint64,\n    max_tlc_value_in_flight:     Uint128,\n    max_tlc_number_in_flight:    Uint64,\n    min_tlc_value:               Uint128,\n    to_self_delay:               Uint64,\n    funding_pubkey:              Byte33,\n    tlc_basepoint:               Byte33,\n    first_per_commitment_point:  Byte33,\n    second_per_commitment_point: Byte33,\n    next_local_nonce:            Byte66,\n    channel_flags:               Byte,\n}\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1235",
+      "id": "chunk-1253",
       "title": "p2p-message",
       "content": "- chain_hash: Chain genesis block hash\n- channel_id: The ID of the channel, which is a temporary ID derived from the tlc_basepoint before the channel is officially established. After the channel is established, it will be replaced with the actual channel ID, derived from a blake2b hash of the sorted tlc_basepoints of both parties.\n- funding_type_script: Specifies the asset type of the channel. If empty, it indicates using CKB native token as the asset.\n- funding_amount: The amount of assets the channel initiator wants to contribute.\n- funding_fee_rate: Funding transaction fee rate, in shannons per kilo-bytes.\n- commitment_fee_rate: Commitment transaction fee rate, in shannons per kilo-bytes.\n- max_tlc_value_in_flight: The maximum total value of unconfirmed TLCs (Time Locked Contracts) that the channel initiator can accept in this channel.\n- max_tlc_number_in_flight: The maximum number of unconfirmed TLCs that the channel initiator can accept in this channel.\n- min_tlc_value: The minimum value of TLCs that the channel initiator can accept.\n- commitment_delay_epoch: The delay time for the channel initiator to unlock the outputs from the commitment transaction, in EpochNumberWithFraction.\n- funding_pubkey: The pubkey of the channel initiator, used for generating 2-2 multisig contracts.\n- tlc_basepoint: The master key used to derive child keys required for tlcs, we will use the same method as lightning network to derive these keys, see [Secret Derivations] for more details.\n- first_per_commitment_point:\n- second_per_commitment_point:\n- next_local_nonce: Used for generating partial signatures for unlocking 2-2 Schnorr multisig.\n- channel_flags: Channel flags, currently only using one bit to indicate whether to broadcast this channel information on the P2P network.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1236",
+      "id": "chunk-1254",
       "title": "p2p-message",
       "content": "### AcceptChannel\n\n`AcceptChannel` is sent by the receiver of the channel to the initiator of the channel to accept the establishment of a payment channel.\n\n```\ntable AcceptChannel {\n    channel_id:                  Byte32,\n    funding_amount:              Uint128,\n    max_tlc_value_in_flight:     Uint128,\n    max_tlc_number_in_flight:    Uint64,\n    min_tlc_value:               Uint128,\n    funding_pubkey:              Byte33,\n    tlc_basepoint:               Byte33,\n    payment_basepoint:           Byte33,\n    delayed_payment_basepoint:   Byte33,\n    first_per_commitment_point:  Byte33,\n    second_per_commitment_point: Byte33,\n    next_local_nonce:            Byte66,\n}\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1237",
+      "id": "chunk-1255",
       "title": "p2p-message",
       "content": "- channel_id: The ID of the channel, must match the channel_id in OpenChannel.\n- funding_amount: The amount of assets the channel receiver wants to contribute, can be 0, indicating no contribution.\n- max_tlc_value_in_flight: The maximum total value of unconfirmed TLCs that the channel receiver can accept in this channel.\n- max_tlc_number_in_flight: The maximum number of unconfirmed TLCs that the channel receiver can accept in this channel.\n- min_tlc_value: The minimum value of TLCs that the channel receiver can accept.\n- funding_pubkey: The pubkey of the channel receiver, used for generating 2-2 multisig contracts.\n- tlc_basepoint: See the description in `OpenChannel` message.\n- first_per_commitment_point:\n- second_per_commitment_point:\n- next_local_nonce: Used for generating partial signatures for unlocking 2-2 Schnorr multisig.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1238",
+      "id": "chunk-1256",
       "title": "p2p-message",
       "content": "### CommitmentSigned\n\nAfter both parties establish the funding transaction and complete the signing of the commitment transaction in the [Transaction Collaboration](#Transaction-Collaboration) process, they will send CommitmentSigned messages to each other.\n\n```\ntable CommitmentSigned {\n    channel_id:        Byte32,\n\tpartial_signature: Byte32,\n    next_local_nonce:  Byte66,\n}\n```\n\nThe meaning of each field is as follows:\n\n- partial_signature: The partial signature for unlocking the 2-2 Schnorr multisig.\n- next_local_nonce: Used for generating the next commitment transaction partial signature.\n\n### TxSignatures",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1239",
+      "id": "chunk-1257",
       "title": "p2p-message",
       "content": "After both parties have signed the commitment transaction and verified the correctness of each other's signatures, they need to send TxSignatures messages to each other to complete the signing of the funding transaction.\n\n```\ntable TxSignatures {\n    channel_id: Byte32,\n    tx_hash:    Byte32,\n    witnesses:  BytesVec,\n}\n```\n\nHere, tx_hash is the hash of the corresponding funding transaction, and witnesses corresponds to the signed witnesses of all inputs of the contributor. If a party's contribution is 0 (i.e., no inputs), an empty witnesses message should also be sent to complete the message exchange.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1240",
+      "id": "chunk-1258",
       "title": "p2p-message",
       "content": "In addition, in order to simplify the message interaction process, we defined that the party with the lesser amount of funding must send the\nTxSignatures message first, in the case of the same amount, the one with the smaller funding_pubkey must send the TxSignatures message first. This avoids deadlocks caused by both parties waiting for the other party's TxSignatures message at the same time.\n\n### ChannelReady\n\nAfter completing the signing and broadcasting the funding transaction, both parties send ChannelReady messages to each other to indicate the channel is ready.\n\n```\ntable ChannelReady {\n    channel_id: Byte32,\n}\n```\n\n## Transaction Collaboration",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1241",
+      "id": "chunk-1259",
       "title": "p2p-message",
       "content": "In the fiber network, the channel initiator begins the transaction construction protocol using the TxUpdate message. The responder replies with either TxUpdate or TxComplete messages. The transaction construction process is completed when both nodes have sent and received consecutive TxComplete messages.\n\nHere is the `Dual Funding` example, A initially funds part of the channel (2 inputs), then B adds their contribution (1 input). A replies with TxComplete, and B responds with TxComplete, completing the transaction construction process.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1242",
+      "id": "chunk-1260",
       "title": "p2p-message",
       "content": "```\n    +-------+                       +-------+\n    |       |--(1)- tx_update   --->|       |\n    |       |<-(2)- tx_update   ----|       |\n    |   A   |--(3)- tx_complete --->|   B   |\n    |       |<-(4)- tx_complete ----|       |\n    +-------+                       +-------+\n```\n\nSince CKB's transaction structure is more complex than Bitcoin's, the message structure is simplified compared to BOLT 02 interactive transaction construction. We use the full CKB transaction structure for transaction collaboration, without defining separate messages like tx_add_input, tx_add_output, tx_remove_input, and tx_remove_output. Nodes are required to parse the inputs of the transactions and do not need to provide previous tx in the messages. The specific message definitions are as follows:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1243",
+      "id": "chunk-1261",
       "title": "p2p-message",
       "content": "### TxUpdate\n\nThe TxUpdate message is used by the channel initiator to start the transaction construction protocol.\n\n```\ntable TxUpdate {\n    channel_id: Byte32,\n    tx:         Transaction,\n}\n```\n\nBoth parties must save the funding tx field of the previous message to compare it with the latest message field. They must also mark which inputs/outputs belong to their side. If a TxUpdate message from the other party removes or modifies inputs/outputs from their side, it is considered an illegal operation, and the entire process should be terminated.\n\n#### Peer-added complexity limits",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1244",
+      "id": "chunk-1262",
       "title": "p2p-message",
       "content": "Verifying a peer's `tx` requires one chain lookup per peer-added input, so an unbounded `TxUpdate` lets a single message amplify into many chain RPC requests. To bound this, a node MUST reject a `TxUpdate` whose `tx` exceeds any of the following peer-added limits relative to its own previous version of the funding transaction, before performing any chain lookup. When the local node still has the default empty funding transaction, these deltas equal the remote transaction totals. The rejection is signalled with a `TxAbort` describing the violated budget.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1245",
+      "id": "chunk-1263",
       "title": "p2p-message",
       "content": "| Limit | Maximum |\n| --- | --- |\n| Serialized transaction size (in block) | `133120` bytes (the P2P frame cap, `1024 * (128 + 2)`) |\n| Peer-added inputs (beyond the local version) | `64` |\n| Peer-added outputs (beyond the local version) | `3` (funding cell plus UDT and CKB change when the peer funds first; CKB-only channels use two) |\n| Peer-added cell deps (beyond the local version) | `8` |\n\nThese values are the implementation defaults; future versions may make them configurable and advertise them during connection or channel negotiation so the initiator can build a compliant transaction up front.\n\n### TxComplete",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1246",
+      "id": "chunk-1264",
       "title": "p2p-message",
       "content": "After successfully exchanging TxComplete messages, both parties should have constructed the transaction and move to the next part of the protocol to exchange signatures for the commitment transaction.\n\n```\ntable TxComplete {\n    channel_id: Byte32,\n}\n```\n\n### TxAbort\n\nDuring the transaction collaboration process, a node can send a TxAbort message to terminate the collaboration before sending the TxSignatures message.\n\n```\ntable TxAbort {\n    channel_id: Byte32,\n    message:    Bytes,\n}\n```\n\n### TxInitRbf\n\nAfter broadcasting the funding transaction, if the channel initiator finds that the fee is insufficient, they can send a TxInitRbf message to request the other party's cooperation in performing RBF (Replace-By-Fee) operation to increase the fee and rebroadcast the funding transaction.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1247",
+      "id": "chunk-1265",
       "title": "p2p-message",
       "content": "```\ntable TxInitRBF {\n    channel_id: Byte32,\n    fee_rate:   Uint64,\n}\n```\n\n### TxAckRbf\n\nUpon receiving a TxInitRbf message, the channel responder can send a TxAckRbf message to agree to the RBF operation.\n\n```\ntable TxAckRBF {\n    channel_id: Byte32,\n}\n```\n\nAfter receiving the TxAckRbf message from the other party, the channel initiator can restart the process of funding transaction collaboration with the new fee rate. It should be noted that the new funding transaction must have overlapping inputs with the previous funding transaction to ensure it meets the RBF rules.\n\n## Channel Closing\n\nNodes can negotiate to close a channel mutually, unlike a unilateral close, which allows nodes to immediately obtain funds. The process of closing a channel is as follows:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1248",
+      "id": "chunk-1266",
       "title": "p2p-message",
       "content": "```\n    +-------+                             +-------+\n    |       |--(1)- shutdown           -->|       |\n    |       |<-(2)- shutdown           ---|       |\n    |   A   | <complete all pending TLCs> |   B   |\n    |       |<-(3)- closing_signed     ---|       |\n    |       |--(4)- closing_signed     -->|       |\n    +-------+                             +-------+\n```\n\n### Shutdown\n\nAny node can send a Shutdown message to request the closure of the channel.\n\n```\ntable Shutdown {\n    channel_id:   Byte32,\n    close_script: Script,\n    fee_rate:     Uint64,\n}\n```\n\nThe close_script specifies the lock script to which the assets will be sent when the channel is closed.\n\n### ClosingSigned",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1249",
+      "id": "chunk-1267",
       "title": "p2p-message",
       "content": "After completing all pending Time Locked Contracts (TLCs) in the channel, either party can send a ClosingSigned message to sign the close transaction.\n\n```\ntable ClosingSigned {\n    channel_id:         Byte32,\n    partial_signature:  Byte32,\n}\n```\n\nIf the receiver verified the correctness of the signature, they will respond with a ClosingSigned message, completing the channel closure.\n\n## Payment Operation\n\nAfter establishing a channel, nodes can perform payment operations by sending AddTlc messages for payment requests and then updating the commitment transactions through CommitmentSigned and RevokeAndAck messages. Here is an example process:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1250",
+      "id": "chunk-1268",
       "title": "p2p-message",
       "content": "```\n    +-------+                               +-------+\n    |       |--(1)---- add_tlc         ---->|       |\n    |       |                               |       |\n    |       |--(2)---- commitment_signed -->|       |\n    |       |<-(3)---- revoke_and_ack  -----|       |\n    |       |                               |       |\n    |       |<-(4)---- commitment_signed ---|       |\n    |       |--(5)---- revoke_and_ack  ---->|       |\n    |       |                               |       |\n    |   A   |                               |   B   |\n    |       |                               |       |\n    |       |<-(6)---- remove_tlc      -----|       |\n    |       |                               |       |\n    |       |<-(7)---- commitment_signed ---|       |\n    |       |--(8)---- revoke_and_ack  ---->|       |\n    |       |                               |       |\n    |       |--(9)---- commitment_signed -->|       |\n    |       |<-(10)---- revoke_and_ack  ----|       |\n    +-------+                               +-------+\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1251",
+      "id": "chunk-1269",
       "title": "p2p-message",
       "content": "### AddTlc\n\nEither node can send an AddTlc message to the other party to initiate a payment operation. This message can also be used to forward payment requests from other nodes.\n\n```\ntable AddTlc {\n    channel_id:     Byte32,\n    tlc_id:         Uint64,\n    amount:         Uint128,\n    payment_hash:   Byte32,\n    expiry:         Uint64,\n}\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1252",
+      "id": "chunk-1270",
       "title": "p2p-message",
       "content": "- channel_id: ID of the channel.\n- tlc_id: ID of the TLC (Time Locked Contract), used to uniquely identify a TLC. The first TLC in the channel has an ID of 0, and subsequent IDs increment by 1.\n- amount: Amount of assets requested for payment.\n- payment_hash: Hash value used to identify the payment request for subsequent payment verification.\n- expiry: Expiry time of the payment request, specified as an absolute timestamp. When forwarding a payment request, this field should be decremented appropriately.\n\n## RevokeAndAck\n\nUpon receiving the CommitmentSigned message and verifying the signature, the node may reveal the previous commitment transaction secret to the other party by sending a RevokeAndAck message.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1253",
+      "id": "chunk-1271",
       "title": "p2p-message",
       "content": "```\ntable RevokeAndAck {\n    channel_id:                 Byte32,\n    per_commitment_secret:      Byte32,\n    next_per_commitment_point:  Byte33,\n    next_local_nonce:           Byte66,\n}\n```\n\n- per_commitment_secret: Secret used to generate the revocation secret key for the previous commitment transaction.\n- next_per_commitment_point: Point used to generate the next revocation public key.\n- next_local_nonce: Used for generating the partial signature for the next commitment transaction.\n\nUpon receiving the RevokeAndAck message, the node should update the remote commitment transaction.\n\n## RemoveTlc\n\nTo simplify the implementation, only the recipient of the AddTkc message can remove the TLC.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1254",
+      "id": "chunk-1272",
       "title": "p2p-message",
       "content": "```\ntable RemoveTlc {\n    channel_id:         Byte32,\n    tlc_id:             Uint64,\n    reason:             RemoveTlcReason\n}\n\nunion RemoveTlcReason {\n    RemoveTlcFulfill,\n    RemoveTlcFail,\n}\n\nstruct RemoveTlcFulfill {\n    payment_preimage:   Byte32,\n}\n\nstruct RemoveTlcFail {\n    error_code:         Uint32,\n}\n```\n\n- channel_id: ID of the channel.\n- tlc_id: ID of the TLC being removed.\n- reason: Reason for removing the TLC, which can be either RemoveTlcFulfill or RemoveTlcFail.\n    - RemoveTlcFulfill: Contains the payment_preimage required to fulfill the payment.\n    - RemoveTlcFail: Contains an error_code indicating the reason for failure.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1255",
+      "id": "chunk-1273",
       "title": "p2p-message",
       "content": "[BOLT 02]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#channel-establishment-v2\n[Molecule]: https://github.com/nervosnetwork/molecule\n[Secret Derivations]: https://github.com/lnbook/lnbook/blob/54453c7b1cf82186614ab929b80876ba18bdc65d/07_payment_channels.asciidoc#revocation_sidebar",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/p2p-message.md",
       "source": "specs/p2p-message.md"
     },
     {
-      "id": "chunk-1256",
+      "id": "chunk-1274",
       "title": "payment-invoice",
       "content": "# Fiber Network Invoice Protocol\n\n## Overall Design\n\nFiber network invoice will be generated and parsed by Fiber Node, we referred to the design of [BOLT 11](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md), and made some adjustments from an implementation perspective.\n\n- The invoice is encode/decoded base on [molecule](https://github.com/nervosnetwork/molecule), which is widely used in the CKB projects.\n- Instead of using `bech32`, we switch to `bech32m`.\n- The interface and usage is similar to [lightning-invoice](https://github.com/lightningdevkit/rust-lightning/tree/main/lightning-invoice/src) as possible, but not compatible with lightning invoice, any cross-chain compatibility needs will be handled through the hub in FNN.\n\n## Human-readable part",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/payment-invoice.md",
       "source": "specs/payment-invoice.md"
     },
     {
-      "id": "chunk-1257",
+      "id": "chunk-1275",
       "title": "payment-invoice",
       "content": "The human-readable part contains these two most important fields:\n\n1. `prefix`: [mandatory] Specify the currency and network of payment\n    - `fibb` for the CKB mainnet,  `fibb` means `fiber bytes`, since in CKB ecosystem 1 CKB equals 1 Byte.\n    - `fibt` for the CKB testnet\n    - `fibd` for the CKB dev\n2. `amount`: [optional] An optional number in that currency.\n    - A standalone number, means the amount of CKB or UDT, for CKB it will be in unit of `shannon`, 1 CKB = 10^8 shannon\n    - An empty value for this field means the amount of payment is not specified, which maybe used in the scenario of donation.\n\n## Encoding and Decoding",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/payment-invoice.md",
       "source": "specs/payment-invoice.md"
     },
     {
-      "id": "chunk-1258",
+      "id": "chunk-1276",
       "title": "payment-invoice",
       "content": "With `molecule`, the data part can be easily converted to bytes. Considering that the bytes generated by molecule are not optimized for space and may contain consecutive zeros when certain fields are empty, the result from `bechm32` encoding is relatively long. We use [arcode-rs](https://github.com/cgbur/arcode-rs) to compress the bytes losslessly before `bechm32` encoding, resulting in a length reduction of almost half:\n\n`data = compressed(data part molecule bytes) + signature`\n\n`encode(&hrp, data, Variant::Bech32m)`\n\nFor decoding, we simply perform the inverse decompression operation.\n\nThe `signature` field: [optional] with type of `[u8; 65]` = 520 bits",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/payment-invoice.md",
       "source": "specs/payment-invoice.md"
     },
     {
-      "id": "chunk-1259",
+      "id": "chunk-1277",
       "title": "payment-invoice",
       "content": "- The secp256k1 signature of the entire invoice, can be used to verify the integrity and correctness of the invoice, may also be used to imply the generator node of this invoice.\nBy default, this filed is none, the method to generate signature:\n  - `message_hash = SHA256-hash (((human-readable part) → bytes) + (data bytes))`\n       then sign it with `Secp256k1`\n  - It may use a customized sign function: `Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key)`\n\n## Data Part\n\nThe data part is designed to add non-mandatory fields easily, and it is very likely that new field will be added in the future:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/payment-invoice.md",
       "source": "specs/payment-invoice.md"
     },
     {
-      "id": "chunk-1260",
+      "id": "chunk-1278",
       "title": "payment-invoice",
       "content": "1. `timestamp`: [mandatory] 128 bits\n    - milliseconds since 1970\n    - The time the invoice was generated\n2. `payment_hash`: [mandatory] 256 bits\n    - SHA256 payment_hash, could specified when creating a invoice, but we need to make sure `payment_hash` is the unique identifier of a invoice.\n    - If creating a `HODL` invoice, a `preimage` parameter must be provided, and the `payment_hash` is generated using `blake2b_256(preimage)` when the invoice is created.\n    - For `AMP invoices` (Atomic Multi-path Payments), the `payment_hash` is randomly generated.\n3. `expiry`: [optional] 32 bits\n    - `timestamp + expiry` is the expiration time of the invoice\n    - Unit: seconds\n4. `description`: [optional] variable length\n    - A string of UTF-8 text to display payment information, such as \"a cup of coffee\"\n5. `final htlc timeout`: [optional] 32 bits\n    - Specifies the final htlc timeout, which may be longer because it may take more hops to reach CKB network\n    - Unit: seconds\n6. `fallback`: [optional] variable length\n    - A CKB address used for fallback in case the invoice payment fails\n7. `feature`: [optional] 32 bits\n    - Feature flag to specify features supported by the payment\n8. `payee_public_key`: [optional] 33 bytes\n    - The public key of the payee\n9. `udt_script`: [optional] variable length\n    - The script specified for the UDT token\n10. `hash_algorithm`: [optional] 1 byte\n    - The hash algorithm used to generate the `payment_hash` from the preimage. When this is missing, the default hash algorithm ckb hash is used.\n        - 0: ckb hash\n        - 1: sha256",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/payment-invoice.md",
       "source": "specs/payment-invoice.md"
     },
     {
-      "id": "chunk-1261",
+      "id": "chunk-1279",
       "title": "trampoline-routing",
       "content": "# Trampoline Routing Specification (Summary)\n\n## What it does (high‑level)\n- The sender only needs to reach the first trampoline node.\n- The rest of the route is encoded inside an inner trampoline onion and forwarded hop‑by‑hop by trampoline nodes.\n- The final recipient only sees the final payload and settles the payment.\n\n## How to use it (RPC)\n- Use `trampoline_hops` in SendPayment RPC to provide explicit trampoline nodes.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1262",
+      "id": "chunk-1280",
       "title": "trampoline-routing",
       "content": "## Fee behavior (summary)\n- A recommended min/max fee is estimated using the default fee rate as a guardrail.\n- The sender attempts to deliver `final_amount + max_fee_amount` to the first trampoline.\n- Any fee spent on the outer route reduces what the first trampoline receives.\n- The remaining fee budget is split evenly across trampoline hops and passed as `build_max_fee_amount`.\n\n# Trampoline Routing Specification\n\n## Summary\n\n### What it does\n- The sender only needs a route to the first trampoline node.\n- The remaining route is encoded in an inner trampoline onion and forwarded hop‑by‑hop.\n- The final recipient only sees the final payload and settles the payment.",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1263",
+      "id": "chunk-1281",
       "title": "trampoline-routing",
       "content": "### How to use it (RPC)\n- Set `trampoline_hops` in SendPayment RPC to explicitly list trampoline nodes.\n  - Reference: [../../crates/fiber-lib/src/rpc/payment.rs](../../crates/fiber-lib/src/rpc/payment.rs#L131-L148)\n\n### Fee behavior\n- A recommended min/max fee is estimated using the default fee rate as a guardrail.\n- The sender routes to the first trampoline with `final_amount + max_fee_amount`.\n- Any fee spent on the outer route reduces what the first trampoline receives.\n- The remaining fee budget is split evenly across trampoline hops and carried as `build_max_fee_amount`.\n  - Construction: [../../crates/fiber-lib/src/fiber/graph.rs](../../crates/fiber-lib/src/fiber/graph.rs#L1294-L1453)\n\nThe forwarding fee calculation follows the standard TLC fee formula:",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1264",
+      "id": "chunk-1282",
       "title": "trampoline-routing",
       "content": "$$\nfee = \\left\\lceil \\frac{amount\\_to\\_forward \\times fee\\_rate}{1{,}000{,}000} \\right\\rceil\n$$\n\n- Implementation: [../../crates/fiber-lib/src/fiber/fee.rs](../../crates/fiber-lib/src/fiber/fee.rs#L115-L142)\n\n### Expiry behavior\n- Each remaining trampoline hop adds a default expiry delta.\n- The total delta must not exceed `tlc_expiry_limit`.\n  - Implementation: [../../crates/fiber-lib/src/fiber/graph.rs](../../crates/fiber-lib/src/fiber/graph.rs#L1481-L1507)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1265",
+      "id": "chunk-1283",
       "title": "trampoline-routing",
       "content": "### Forwarding behavior\n- A trampoline node peels the inner onion, validates amounts, and builds a new payment to the next hop.\n- It checks that the incoming amount covers `amount_to_forward` and that the available fee matches `build_max_fee_amount`.\n  - Implementation: [../../crates/fiber-lib/src/fiber/network.rs](../../crates/fiber-lib/src/fiber/network.rs#L2438-L2550)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1266",
+      "id": "chunk-1284",
       "title": "trampoline-routing",
       "content": "### Known constraints\n- Max trampoline hops: `MAX_TRAMPOLINE_HOPS_LIMIT` (5)\n  - [../../crates/fiber-lib/src/fiber/payment.rs](../../crates/fiber-lib/src/fiber/payment.rs#L46-L50)\n- Trampoline packet size: `TRAMPOLINE_PACKET_DATA_LEN`\n  - [../../crates/fiber-lib/src/fiber/types.rs](../../crates/fiber-lib/src/fiber/types.rs#L3830-L3846)\n- `max_fee_amount` must be provided when `trampoline_hops` is set.\n  - [../../crates/fiber-lib/src/fiber/payment.rs](../../crates/fiber-lib/src/fiber/payment.rs#L365-L385)\n\n### Key payloads\n- Trampoline hop payloads: [../../crates/fiber-lib/src/fiber/types.rs](../../crates/fiber-lib/src/fiber/types.rs#L3773-L3818)\n- Trampoline onion packet: [../../crates/fiber-lib/src/fiber/types.rs](../../crates/fiber-lib/src/fiber/types.rs#L3830-L3846)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1267",
+      "id": "chunk-1285",
       "title": "trampoline-routing",
       "content": "### Tests to validate\n- Graph‑level construction tests: [../../crates/fiber-lib/src/fiber/tests/graph.rs](../../crates/fiber-lib/src/fiber/tests/graph.rs)\n- End‑to‑end trampoline tests: [../../crates/fiber-lib/src/fiber/tests/trampoline.rs](../../crates/fiber-lib/src/fiber/tests/trampoline.rs)\n\n## Detailed Specification\n\n### Overview\nTrampoline routing lets a sender with limited routing information delegate pathfinding to intermediate trampoline nodes. The sender builds a normal outer onion to the first trampoline and embeds an inner trampoline onion that encodes the remaining hops.\n\n```\nSender → [Outer Onion] → First Trampoline → [Inner Onion] → Next Trampoline → ... → Final Recipient\n```",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1268",
+      "id": "chunk-1286",
       "title": "trampoline-routing",
       "content": "### Sender: route construction\n1. Validate `trampoline_hops` and fee budget, and ensure all hops support trampoline routing.\n2. Build a route to the first trampoline for `final_amount + max_fee_amount`.\n3. Allocate the remaining fee budget across trampoline hops as `build_max_fee_amount`.\n4. Build the inner trampoline onion and embed it in the last hop of the outer route.\n\nImplementation details:\n- Route construction and fee allocation: [../../crates/fiber-lib/src/fiber/graph.rs](../../crates/fiber-lib/src/fiber/graph.rs#L1294-L1453)\n- Default‑fee estimation: [../../crates/fiber-lib/src/fiber/graph.rs](../../crates/fiber-lib/src/fiber/graph.rs#L1457-L1478)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     },
     {
-      "id": "chunk-1269",
+      "id": "chunk-1287",
       "title": "trampoline-routing",
       "content": "### Trampoline forwarding\nWhen a trampoline node receives a payment with an embedded trampoline onion, it:\n1. Peels the inner onion.\n2. Validates the forward payload (amount, fee budget, expiry constraints).\n3. Starts a new payment to the next hop with `build_max_fee_amount` as its routing budget.\n\nImplementation:\n- [../../crates/fiber-lib/src/fiber/network.rs](../../crates/fiber-lib/src/fiber/network.rs#L2438-L2550)\n\n### Final recipient processing\nThe final recipient validates the trampoline final payload and settles the TLC with the provided preimage.\n\nImplementation:\n- [../../crates/fiber-lib/src/fiber/channel.rs](../../crates/fiber-lib/src/fiber/channel.rs#L1182-L1195)",
       "url": "https://github.com/nervosnetwork/fiber/blob/main/docs/specs/trampoline-routing.md",
       "source": "specs/trampoline-routing.md"
     }
   ],
-  "generatedAt": "2026-07-20T06:17:27.158Z"
+  "generatedAt": "2026-08-02T14:52:48.330Z"
 }

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -144,8 +144,6 @@ Source: https://www.fiber.world/docs/quick-start/basic-transfer
 
 Set up two local nodes, open a channel between them, and send a CKB payment from one to the other. The whole process takes about 10 minutes.
 
-This page is the native, two-terminal workflow. To start a WASM node directly in your browser and connect it to a public node over WSS, see Run a WASM Node.
-
 ## Overview
 
 This guide walks you through setting up and executing a basic token (CKB) transfer between two nodes on the Fiber Testnet.
@@ -205,8 +203,6 @@ View complete config.yml example
 ### 1. Start Both Nodes
 
 [sh code block]
-
-Keep both terminal processes running while you complete the remaining steps.
 
 ### 2. Connect the Nodes
 


### PR DESCRIPTION
## Summary

- document the automated native-node installer introduced by nervosnetwork/fiber#1262
- add Linux/macOS and Windows Testnet preview flows while keeping the current manual installation path
- explain restart, Mainnet RPC, network isolation, password, and backup requirements
- update the run-a-node overview and backup guide
- refresh tracked knowledge-base outputs

## Release gate

The installer is merged into Fiber develop but is not included in a release yet. The documented automated flow is explicitly marked as a Testnet preview and pins Fiber v0.9.0-rc7 while loading the installer from develop. Before publishing this as the stable path, replace the preview entrypoint with the released installer URL and version.

## Validation

- pnpm build
- MDX type generation
- git diff --check